### PR TITLE
feat: scientific Persian translation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # skills
+
+Skillهای شخصی Cursor. این ریپو را به‌عنوان `~/.cursor/skills` کلون کن تا هر پوشه‌ای که `SKILL.md` دارد به‌صورت خودکار کشف شود.
+
+```bash
+git clone git@github.com:isArman/skills.git ~/.cursor/skills
+```
+
+اگر آن مسیر از قبل وجود دارد، داخل همان پوشه remote اضافه کن یا محتوا را merge کن. بعد از pull، یک‌بار Cursor را باز کن یا `/scientific-fa-translation` را در Agent بزن تا skill دیده شود.
+
+## Skills
+
+| Skill | Invoke | کار |
+| --- | --- | --- |
+| [scientific-fa-translation](scientific-fa-translation/SKILL.md) | `/scientific-fa-translation` | ترجمهٔ علمی به فارسی معیار، RTL دقیق، اصطلاحات تخصصی انگلیسی |

--- a/README.md
+++ b/README.md
@@ -1,15 +1,71 @@
 # skills
 
-Skillهای شخصی Cursor. این ریپو را به‌عنوان `~/.cursor/skills` کلون کن تا هر پوشه‌ای که `SKILL.md` دارد به‌صورت خودکار کشف شود.
+Personal [Cursor Agent Skills](https://cursor.com/docs/skills). Clone this
+repository to `~/.cursor/skills` so every folder that contains a `SKILL.md`
+is discovered automatically.
 
 ```bash
 git clone git@github.com:isArman/skills.git ~/.cursor/skills
 ```
 
-اگر آن مسیر از قبل وجود دارد، داخل همان پوشه remote اضافه کن یا محتوا را merge کن. بعد از pull، یک‌بار Cursor را باز کن یا `/scientific-fa-translation` را در Agent بزن تا skill دیده شود.
+If that path already exists, add this repo as a remote there or merge the
+contents. After `git pull`, reload Cursor or type `/scientific-fa-translation`
+in Agent chat to confirm the skill is visible.
+
+Each skill is a directory named after its `name` frontmatter field. Cursor
+walks `~/.cursor/skills` recursively; keep `SKILL.md` in the skill folder,
+not at the repo root.
 
 ## Skills
 
-| Skill | Invoke | کار |
+| Skill | Invoke | Purpose |
 | --- | --- | --- |
-| [scientific-fa-translation](scientific-fa-translation/SKILL.md) | `/scientific-fa-translation` | ترجمهٔ علمی به فارسی معیار؛ PDF چاپی با RTL دقیق در `~/Documents/books` |
+| [scientific-fa-translation](scientific-fa-translation/SKILL.md) | `/scientific-fa-translation` | Academic English → Persian translation; print PDF with precise RTL at `~/Documents/books` |
+
+### scientific-fa-translation
+
+Translates papers, articles, books, and technical documentation into
+formal scientific Persian. Cursor chat is only a short status note plus
+the output path. It is not the RTL surface.
+
+**Deliverable.** A printable PDF at `~/Documents/books/<slug>.pdf`,
+created if needed. Preferred engine: XeLaTeX + `xepersian`
+(`assets/rtl-document.tex`). Fallback: Chromium print of the RTL HTML
+template. HTML is produced only when asked for, or as that fallback.
+
+**Keep English** (LTR-isolated; no فرهنگستان coinages):
+
+- Algorithm, library, protocol, and product names
+- Acronyms such as `API`, `PCR`, `GPU`, `CI`
+- Formulas, code, units, and statistics (`p`, `n`, `SD`)
+- People’s names, journal names, and DOIs
+
+**Write in Persian** (do not leave these in English):
+
+- Verbs and sentence structure
+- General scholarly words (روش، نتایج، بررسی)
+- Section titles (مقدمه، بحث)
+- Conceptual explanation for the reader
+
+**Also locked:** Western digits; figure labels like `شکل 3`; source
+images unchanged (no mirroring or redrawing); code blocks always LTR
+and left-aligned; bibliography not translated; ask on scientific
+ambiguity.
+
+Layout:
+
+```text
+scientific-fa-translation/
+  SKILL.md
+  assets/rtl-document.tex
+  assets/rtl-document.html
+  references/scientific-style.md
+  references/rtl-bidi.md
+  references/pdf-output.md
+  references/glossary.md
+  scripts/build-pdf.sh
+```
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ git clone git@github.com:isArman/skills.git ~/.cursor/skills
 
 | Skill | Invoke | کار |
 | --- | --- | --- |
-| [scientific-fa-translation](scientific-fa-translation/SKILL.md) | `/scientific-fa-translation` | ترجمهٔ علمی به فارسی معیار، RTL دقیق، اصطلاحات تخصصی انگلیسی |
+| [scientific-fa-translation](scientific-fa-translation/SKILL.md) | `/scientific-fa-translation` | ترجمهٔ علمی به فارسی معیار؛ PDF چاپی با RTL دقیق در `~/Documents/books` |

--- a/scientific-fa-translation/SKILL.md
+++ b/scientific-fa-translation/SKILL.md
@@ -39,6 +39,8 @@ Override only when the user says so.
 | Output | UTF-8 HTML file from `assets/rtl-document.html` (`lang="fa"` `dir="rtl"`). |
 | Digits | Western (`3.14`, not `۳٫۱۴`). |
 | Figures/tables | `شکل 3`, `جدول 2` — label translated, number unchanged. |
+| Images | Same files, order, size, and placement as the source. Do not mirror, crop, redraw, or drop. |
+| Code blocks | Always LTR and left-aligned. Never RTL, never `text-align: right`. |
 | Abstract/footnotes | Translate. |
 | Bibliography | Do not translate (authors, titles, journals, DOIs, URLs). |
 | Ambiguity | Ask. Do not guess a scientific claim. |
@@ -53,7 +55,8 @@ note that points to the file is enough.
 2. Read `references/scientific-style.md` and `references/rtl-bidi.md`
    before drafting.
 3. Inventory structure: headings, figures, tables, equations, code,
-   footnotes, citations.
+   footnotes, citations. Copy every source image into the output
+   tree and keep the same sequence relative to the surrounding text.
 4. Scan domain terms. Check `references/glossary.md`. New terms stay
    English; append them to the glossary.
 5. Translate section by section. Do not add, omit, or soften claims.
@@ -80,7 +83,8 @@ Leave these in an LTR isolate. Do not Persianize them.
 - Paper titles inside the reference list
 
 Translate ordinary prose: methods, results, discussion, captions (except
-identifiers), and structural headings (`مقدمه`, `روش‌ها`, `نتایج`, `بحث`).
+identifiers and the image files themselves), and structural headings
+(`مقدمه`, `روش‌ها`, `نتایج`, `بحث`).
 
 Do not translate filler words into English. `paper` → مقاله, `method` →
 روش, `result` → نتیجه — unless the glossary marks that token as a proper
@@ -102,11 +106,15 @@ Full rules: `references/rtl-bidi.md`. Non-negotiable.
 
 - Root element: `lang="fa"` `dir="rtl"`.
 - Start from `assets/rtl-document.html`.
-- Isolate every English term, number cluster, formula, URL, and code
-  span with `<span dir="ltr">…</span>` or `<bdi>`.
-- `pre`, `code`, and math blocks are LTR.
+- Isolate every English term, number cluster, formula, URL, and inline
+  code with `<span dir="ltr">…</span>` or `<bdi>`.
+- Code blocks (`pre`, fenced listings, `code` blocks) are LTR and
+  left-aligned. Put `dir="ltr"` on the `<pre>` itself. Never inherit
+  RTL from `body`. Never right-align code.
+- Math blocks are LTR.
 - Do not reverse English letters. Do not hand-flip parentheses; isolate
   the LTR span instead.
+- Do not mirror images for RTL. Figures keep the source pixels/SVG.
 - After an English insertion at the end of a Persian sentence, the
   Persian period must belong to that sentence (isolation or RLM).
 
@@ -116,7 +124,10 @@ Full rules: `references/rtl-bidi.md`. Non-negotiable.
 2. Set `<title>` and keep the CSS.
 3. Put translation in `<body>`. Headings, lists, and footnotes stay.
 4. Translate captions; keep identifiers (`Figure 3` → `شکل 3`).
-5. Leave the reference list in the source language, in an LTR section.
+5. Embed each source image with the original `src` (or a copied asset
+   of the same file). Preserve order, aspect ratio, and subfigure
+   layout. Do not regenerate or flip artwork.
+6. Leave the reference list in the source language, in an LTR section.
 
 ## Quality checklist
 
@@ -126,5 +137,7 @@ Full rules: `references/rtl-bidi.md`. Non-negotiable.
 - [ ] Citations, equations, numbers, and units unchanged
 - [ ] `ک`/`ی` Persian; نیم‌فاصله present; no colloquial forms
 - [ ] Every mixed LTR run is isolated; punctuation attaches correctly
+- [ ] Every code block is `dir="ltr"`, left-aligned, source text unchanged
+- [ ] Every source image is present, unmirrored, in the same place
 - [ ] Bibliography, DOIs, and URLs not translated
 - [ ] Deliverable is a `dir="rtl"` file, not chat-only Markdown

--- a/scientific-fa-translation/SKILL.md
+++ b/scientific-fa-translation/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Translate scientific documents, papers, articles, books, and technical
   docs into academic Persian (Farsi) with strict RTL/bidi and untranslated
   English technical terms. Use when the user asks to ترجمه, translate a
-  paper/article/book/docs, راست‌چین, RTL, or Persian scientific translation.
+  paper/article/book/docs, راست‌چین, RTL, PDF, چاپ, or Persian scientific
+  translation.
   Do NOT use for coding, explaining code, commit messages, UI copy,
   literary translation, or casual Persian chat.
 ---
@@ -12,13 +13,13 @@ description: >
 # Scientific Persian translation
 
 English → academic Persian for papers, articles, books, and technical
-documentation. Accuracy, consistent terminology, and correct RTL/bidi
-outrank literary fluency.
+documentation. Accuracy, consistent terminology, and print-ready RTL
+outrank literary fluency. Cursor chat is not the RTL surface.
 
 ## When to use
 
 - Translate a scientific or technical document into Persian.
-- User mentions ترجمه علمی, راست‌چین, RTL, paper, article, or book.
+- User mentions ترجمه علمی, راست‌چین, RTL, PDF, چاپ, paper, article, or book.
 
 ## When not to use
 
@@ -36,7 +37,9 @@ Override only when the user says so.
 | Register | Formal فارسی معیار. No colloquial forms. |
 | Technical terms | Keep English. Do not invent فرهنگستان equivalents. |
 | First mention | English only. No Persian gloss unless `references/glossary.md` says so. |
-| Output | UTF-8 HTML file from `assets/rtl-document.html` (`lang="fa"` `dir="rtl"`). |
+| Output | Printable PDF at `~/Documents/books/<slug>.pdf`. Chat is a short pointer, not RTL. |
+| PDF RTL | Maximum precision via XeLaTeX + `xepersian`. See `references/pdf-output.md`. |
+| HTML | Only if the user asks for HTML, or as the Chromium-print fallback. |
 | Digits | Western (`3.14`, not `۳٫۱۴`). |
 | Figures/tables | `شکل 3`, `جدول 2` — label translated, number unchanged. |
 | Images | Same files, order, size, and placement as the source. Do not mirror, crop, redraw, or drop. |
@@ -45,30 +48,33 @@ Override only when the user says so.
 | Bibliography | Do not translate (authors, titles, journals, DOIs, URLs). |
 | Ambiguity | Ask. Do not guess a scientific claim. |
 
-Chat Markdown cannot do precise RTL. Always write a file. A short chat
-note that points to the file is enough.
+Chat is a short status note plus the PDF path. Do not right-align the
+conversation and do not paste the article into chat.
 
 ## Workflow
 
-1. Confirm source, target (default EN→FA), and output path. If the user
-   pastes text, still write an HTML file named from the source title.
+1. Confirm source and target (default EN→FA). Default deliverable is a
+   PDF. Read `references/pdf-output.md` before compiling.
 2. Read `references/scientific-style.md` and `references/rtl-bidi.md`
    before drafting.
 3. Inventory structure: headings, figures, tables, equations, code,
-   footnotes, citations. Copy every source image into the output
-   tree and keep the same sequence relative to the surrounding text.
+   footnotes, citations. Copy every source image into the working
+   tree (`figures/` next to the `.tex`) and keep the same sequence
+   relative to the surrounding text.
 4. Scan domain terms. Check `references/glossary.md`. New terms stay
    English; append them to the glossary.
 5. Translate section by section. Do not add, omit, or soften claims.
    Preserve hedge language (`may`, `might`, `suggest`, `remain unknown`).
-6. RTL pass: isolate every LTR run. See `references/rtl-bidi.md`.
+6. RTL pass on the print source (`.tex` with `\lr` / `latin`, or HTML
+   isolation if falling back). See `references/rtl-bidi.md`.
 7. Consistency pass: same English term for the same concept throughout.
-8. Run the checklist below before finishing.
+8. Compile the PDF to `~/Documents/books/<slug>.pdf`. Run the checklist.
 
-If the user asks for Markdown, wrap the body in `<div lang="fa" dir="rtl">`
-and still isolate LTR spans. If they ask for XeLaTeX/`xepersian`, say so
-and keep math LTR. Reverse translation (FA→EN) only on explicit request;
-then drop RTL rules and keep technical terms in English.
+If the user asks for HTML only, use `assets/rtl-document.html`. If they
+ask for Markdown, wrap the body in `<div lang="fa" dir="rtl">` and still
+isolate LTR spans; say that print RTL will be weaker than PDF. Reverse
+translation (FA→EN) only on explicit request; then drop RTL rules and
+keep technical terms in English.
 
 ## What stays English
 
@@ -102,32 +108,43 @@ Full rules: `references/scientific-style.md`.
 
 ## RTL
 
-Full rules: `references/rtl-bidi.md`. Non-negotiable.
+Full rules: `references/rtl-bidi.md`. For PDF: `references/pdf-output.md`.
 
-- Root element: `lang="fa"` `dir="rtl"`.
-- Start from `assets/rtl-document.html`.
+Chat does not need to be RTL.
+
+On the **PDF** (non-negotiable when producing a printable file):
+
+- Prefer XeLaTeX + `xepersian` from `assets/rtl-document.tex`.
 - Isolate every English term, number cluster, formula, URL, and inline
-  code with `<span dir="ltr">…</span>` or `<bdi>`.
-- Code blocks (`pre`, fenced listings, `code` blocks) are LTR and
-  left-aligned. Put `dir="ltr"` on the `<pre>` itself. Never inherit
-  RTL from `body`. Never right-align code.
-- Math blocks are LTR.
-- Do not reverse English letters. Do not hand-flip parentheses; isolate
-  the LTR span instead.
-- Do not mirror images for RTL. Figures keep the source pixels/SVG.
+  code with `\lr{…}` (or `<span dir="ltr">` on the HTML fallback).
+- Code listings are LTR and left-aligned: `latin` + `verbatim` /
+  `Verbatim`, or `<pre dir="ltr">`. Never RTL, never right-aligned.
+- Math stays LTR. Do not reverse English letters or hand-flip
+  parentheses.
+- Do not mirror images. `\includegraphics` / `<img>` the source files.
 - After an English insertion at the end of a Persian sentence, the
-  Persian period must belong to that sentence (isolation or RLM).
+  Persian period must belong to that sentence (`\lr` isolation or RLM).
 
 ## Output
 
-1. Copy `assets/rtl-document.html`.
-2. Set `<title>` and keep the CSS.
-3. Put translation in `<body>`. Headings, lists, and footnotes stay.
-4. Translate captions; keep identifiers (`Figure 3` → `شکل 3`).
-5. Embed each source image with the original `src` (or a copied asset
-   of the same file). Preserve order, aspect ratio, and subfigure
-   layout. Do not regenerate or flip artwork.
-6. Leave the reference list in the source language, in an LTR section.
+Default: printable PDF. Always save the final file at
+`~/Documents/books/<slug>.pdf` (`$HOME/Documents/books`). Create the
+directory if needed. Report that absolute path in chat.
+
+1. Read `references/pdf-output.md`. Prefer `assets/rtl-document.tex`.
+2. Put Persian prose in the `.tex`. Wrap English runs with `\lr{…}`
+   or `\en{…}`.
+3. Listings in `\begin{latin}…\end{latin}`. Captions translated;
+   identifiers kept (`Figure 3` → `شکل 3`).
+4. `\includegraphics` each source image (copied into `figures/`).
+   Preserve order, aspect ratio, and subfigure layout. Do not
+   regenerate or flip artwork.
+5. Bibliography in a `latin` section, source language.
+6. `scripts/build-pdf.sh path/to/doc.tex <slug>`
+   → `$HOME/Documents/books/<slug>.pdf`.
+
+HTML (`assets/rtl-document.html`) is only for an explicit HTML ask or
+the Chromium-print fallback in `references/pdf-output.md`.
 
 ## Quality checklist
 
@@ -136,8 +153,9 @@ Full rules: `references/rtl-bidi.md`. Non-negotiable.
 - [ ] Terms match the glossary; no silent Persianization of jargon
 - [ ] Citations, equations, numbers, and units unchanged
 - [ ] `ک`/`ی` Persian; نیم‌فاصله present; no colloquial forms
-- [ ] Every mixed LTR run is isolated; punctuation attaches correctly
-- [ ] Every code block is `dir="ltr"`, left-aligned, source text unchanged
+- [ ] Every mixed LTR run is isolated (`\lr` / `dir="ltr"`); punctuation attaches correctly
+- [ ] Every code block is LTR, left-aligned, source text unchanged
 - [ ] Every source image is present, unmirrored, in the same place
 - [ ] Bibliography, DOIs, and URLs not translated
-- [ ] Deliverable is a `dir="rtl"` file, not chat-only Markdown
+- [ ] Chat is a short pointer, not an RTL article
+- [ ] Final PDF exists at `~/Documents/books/<slug>.pdf`

--- a/scientific-fa-translation/SKILL.md
+++ b/scientific-fa-translation/SKILL.md
@@ -35,8 +35,8 @@ Override only when the user says so.
 | --- | --- |
 | Direction | English → فارسی علمی |
 | Register | Formal فارسی معیار. No colloquial forms. |
-| Technical terms | Keep English. Do not invent فرهنگستان equivalents. |
-| First mention | English only. No Persian gloss unless `references/glossary.md` says so. |
+| Technical terms | Named artifacts stay English. General scholarly language is Persian. See below. |
+| First mention | Named English terms: English only, no gloss, unless `references/glossary.md` says so. |
 | Output | Printable PDF at `~/Documents/books/<slug>.pdf`. Chat is a short pointer, not RTL. |
 | PDF RTL | Maximum precision via XeLaTeX + `xepersian`. See `references/pdf-output.md`. |
 | HTML | Only if the user asks for HTML, or as the Chromium-print fallback. |
@@ -61,8 +61,8 @@ conversation and do not paste the article into chat.
    footnotes, citations. Copy every source image into the working
    tree (`figures/` next to the `.tex`) and keep the same sequence
    relative to the surrounding text.
-4. Scan domain terms. Check `references/glossary.md`. New terms stay
-   English; append them to the glossary.
+4. Scan domain terms. Check `references/glossary.md`. New *names*
+   stay English; new general words get a Persian row. Append both.
 5. Translate section by section. Do not add, omit, or soften claims.
    Preserve hedge language (`may`, `might`, `suggest`, `remain unknown`).
 6. RTL pass on the print source (`.tex` with `\lr` / `latin`, or HTML
@@ -76,25 +76,34 @@ isolate LTR spans; say that print RTL will be weaker than PDF. Reverse
 translation (FA→EN) only on explicit request; then drop RTL rules and
 keep technical terms in English.
 
-## What stays English
+## Keep English vs write Persian
 
-Leave these in an LTR isolate. Do not Persianize them.
+House split. Full lists: `references/glossary.md`.
 
-- Algorithm, library, protocol, product, and model names
-- Acronyms (`API`, `PCR`, `GPU`, `CI`, `RMSE`)
-- Code, commands, file paths, identifiers
-- LaTeX/math, chemical formulas, gene names, binomial species names
-- Units and statistics (`p`, `n`, `M`, `SD`, `CI`, SI units)
-- Author names, journal and conference names, DOIs, URLs
-- Paper titles inside the reference list
+**Keep English** (LTR isolate: `\lr` / `<span dir="ltr">`). Do not
+Persianize. Do not invent فرهنگستان equivalents.
 
-Translate ordinary prose: methods, results, discussion, captions (except
-identifiers and the image files themselves), and structural headings
-(`مقدمه`, `روش‌ها`, `نتایج`, `بحث`).
+- Names of algorithms, libraries, protocols, and products
+- Acronyms: `API`, `PCR`, `GPU`, `CI`, and others of that kind
+- Formulas, code, units, and statistics (`p`, `n`, `SD`, …)
+- People’s names, journal names, and DOIs
+  (also conference names, URLs, and bibliography titles)
 
-Do not translate filler words into English. `paper` → مقاله, `method` →
-روش, `result` → نتیجه — unless the glossary marks that token as a proper
-name.
+**Write in Persian.** Translate these out of English. Never leave the
+English word in the Persian sentence.
+
+- Verbs and sentence structure
+- General scholarly words: روش، نتایج، بررسی (also مقدمه-level
+  vocabulary: مقاله، روش‌ها، بحث، …)
+- Section titles: مقدمه، بحث، and the rest of the heading table in
+  `references/scientific-style.md`
+- Conceptual explanation for the reader: the surrounding prose that
+  *says what a term means* is Persian. The named term inside it stays
+  English.
+
+Example: «در این روش از \en{gradient descent} برای کمینه کردن تابع
+هزینه استفاده می‌شود.» — روش / کمینه کردن / استفاده می‌شود are
+Persian; `gradient descent` stays English.
 
 ## Persian mechanics
 
@@ -150,7 +159,8 @@ the Chromium-print fallback in `references/pdf-output.md`.
 
 - [ ] No added, omitted, or softened scientific claims
 - [ ] Hedge language preserved
-- [ ] Terms match the glossary; no silent Persianization of jargon
+- [ ] Names/acronyms/formulas/units/stats/people/journals/DOIs stay English
+- [ ] Verbs, general words, section titles, and explanations are Persian
 - [ ] Citations, equations, numbers, and units unchanged
 - [ ] `ک`/`ی` Persian; نیم‌فاصله present; no colloquial forms
 - [ ] Every mixed LTR run is isolated (`\lr` / `dir="ltr"`); punctuation attaches correctly

--- a/scientific-fa-translation/SKILL.md
+++ b/scientific-fa-translation/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: scientific-fa-translation
+description: >
+  Translate scientific documents, papers, articles, books, and technical
+  docs into academic Persian (Farsi) with strict RTL/bidi and untranslated
+  English technical terms. Use when the user asks to ترجمه, translate a
+  paper/article/book/docs, راست‌چین, RTL, or Persian scientific translation.
+  Do NOT use for coding, explaining code, commit messages, UI copy,
+  literary translation, or casual Persian chat.
+---
+
+# Scientific Persian translation
+
+English → academic Persian for papers, articles, books, and technical
+documentation. Accuracy, consistent terminology, and correct RTL/bidi
+outrank literary fluency.
+
+## When to use
+
+- Translate a scientific or technical document into Persian.
+- User mentions ترجمه علمی, راست‌چین, RTL, paper, article, or book.
+
+## When not to use
+
+- Writing, explaining, or reviewing code.
+- Commit messages, PRs, UI copy, literary or marketing translation.
+- Casual Persian conversation that is not a translation request.
+
+## Locked defaults
+
+Override only when the user says so.
+
+| Decision | Default |
+| --- | --- |
+| Direction | English → فارسی علمی |
+| Register | Formal فارسی معیار. No colloquial forms. |
+| Technical terms | Keep English. Do not invent فرهنگستان equivalents. |
+| First mention | English only. No Persian gloss unless `references/glossary.md` says so. |
+| Output | UTF-8 HTML file from `assets/rtl-document.html` (`lang="fa"` `dir="rtl"`). |
+| Digits | Western (`3.14`, not `۳٫۱۴`). |
+| Figures/tables | `شکل 3`, `جدول 2` — label translated, number unchanged. |
+| Abstract/footnotes | Translate. |
+| Bibliography | Do not translate (authors, titles, journals, DOIs, URLs). |
+| Ambiguity | Ask. Do not guess a scientific claim. |
+
+Chat Markdown cannot do precise RTL. Always write a file. A short chat
+note that points to the file is enough.
+
+## Workflow
+
+1. Confirm source, target (default EN→FA), and output path. If the user
+   pastes text, still write an HTML file named from the source title.
+2. Read `references/scientific-style.md` and `references/rtl-bidi.md`
+   before drafting.
+3. Inventory structure: headings, figures, tables, equations, code,
+   footnotes, citations.
+4. Scan domain terms. Check `references/glossary.md`. New terms stay
+   English; append them to the glossary.
+5. Translate section by section. Do not add, omit, or soften claims.
+   Preserve hedge language (`may`, `might`, `suggest`, `remain unknown`).
+6. RTL pass: isolate every LTR run. See `references/rtl-bidi.md`.
+7. Consistency pass: same English term for the same concept throughout.
+8. Run the checklist below before finishing.
+
+If the user asks for Markdown, wrap the body in `<div lang="fa" dir="rtl">`
+and still isolate LTR spans. If they ask for XeLaTeX/`xepersian`, say so
+and keep math LTR. Reverse translation (FA→EN) only on explicit request;
+then drop RTL rules and keep technical terms in English.
+
+## What stays English
+
+Leave these in an LTR isolate. Do not Persianize them.
+
+- Algorithm, library, protocol, product, and model names
+- Acronyms (`API`, `PCR`, `GPU`, `CI`, `RMSE`)
+- Code, commands, file paths, identifiers
+- LaTeX/math, chemical formulas, gene names, binomial species names
+- Units and statistics (`p`, `n`, `M`, `SD`, `CI`, SI units)
+- Author names, journal and conference names, DOIs, URLs
+- Paper titles inside the reference list
+
+Translate ordinary prose: methods, results, discussion, captions (except
+identifiers), and structural headings (`مقدمه`, `روش‌ها`, `نتایج`, `بحث`).
+
+Do not translate filler words into English. `paper` → مقاله, `method` →
+روش, `result` → نتیجه — unless the glossary marks that token as a proper
+name.
+
+## Persian mechanics
+
+Full rules: `references/scientific-style.md`.
+
+- UTF-8. Persian letters only: `ک` not `ك`, `ی` not `ي`.
+- نیم‌فاصله (U+200C) in `می‌شود`, `می‌توان`, `نمی‌کند`, and standard
+  compounds.
+- Punctuation: `،` `؛` `؟` `«»`. Not Latin `,` `;` `?` `""`.
+- Formal verb forms only (`می‌شود` not `میشه`).
+
+## RTL
+
+Full rules: `references/rtl-bidi.md`. Non-negotiable.
+
+- Root element: `lang="fa"` `dir="rtl"`.
+- Start from `assets/rtl-document.html`.
+- Isolate every English term, number cluster, formula, URL, and code
+  span with `<span dir="ltr">…</span>` or `<bdi>`.
+- `pre`, `code`, and math blocks are LTR.
+- Do not reverse English letters. Do not hand-flip parentheses; isolate
+  the LTR span instead.
+- After an English insertion at the end of a Persian sentence, the
+  Persian period must belong to that sentence (isolation or RLM).
+
+## Output
+
+1. Copy `assets/rtl-document.html`.
+2. Set `<title>` and keep the CSS.
+3. Put translation in `<body>`. Headings, lists, and footnotes stay.
+4. Translate captions; keep identifiers (`Figure 3` → `شکل 3`).
+5. Leave the reference list in the source language, in an LTR section.
+
+## Quality checklist
+
+- [ ] No added, omitted, or softened scientific claims
+- [ ] Hedge language preserved
+- [ ] Terms match the glossary; no silent Persianization of jargon
+- [ ] Citations, equations, numbers, and units unchanged
+- [ ] `ک`/`ی` Persian; نیم‌فاصله present; no colloquial forms
+- [ ] Every mixed LTR run is isolated; punctuation attaches correctly
+- [ ] Bibliography, DOIs, and URLs not translated
+- [ ] Deliverable is a `dir="rtl"` file, not chat-only Markdown

--- a/scientific-fa-translation/assets/rtl-document.html
+++ b/scientific-fa-translation/assets/rtl-document.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TITLE</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      margin: 1.5rem auto;
+      max-width: 46rem;
+      padding: 0 1rem 3rem;
+      direction: rtl;
+      unicode-bidi: isolate;
+      font-family: "Vazirmatn", "Tahoma", "Segoe UI", sans-serif;
+      line-height: 1.85;
+    }
+    h1, h2, h3, h4 {
+      line-height: 1.45;
+    }
+    p {
+      margin: 0.85em 0;
+    }
+    .ltr,
+    pre,
+    code,
+    kbd,
+    samp,
+    math {
+      direction: ltr;
+      unicode-bidi: isolate;
+    }
+    pre {
+      overflow-x: auto;
+      padding: 0.75rem 1rem;
+      text-align: left;
+    }
+    code {
+      font-family: ui-monospace, "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+      font-size: 0.92em;
+    }
+    a[dir="ltr"] {
+      unicode-bidi: isolate;
+    }
+    figure {
+      margin: 1.5rem 0;
+    }
+    figcaption, caption {
+      font-size: 0.95em;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+    th, td {
+      border: 1px solid currentColor;
+      padding: 0.4rem 0.6rem;
+    }
+    td.num, th.num {
+      direction: ltr;
+      unicode-bidi: isolate;
+      text-align: left;
+    }
+    .refs {
+      direction: ltr;
+      unicode-bidi: isolate;
+      text-align: left;
+    }
+    .refs h2 {
+      direction: rtl;
+      unicode-bidi: isolate;
+      text-align: right;
+    }
+  </style>
+</head>
+<body>
+  <h1>TITLE</h1>
+
+  <!--
+    Isolate every English term, number cluster, formula, URL, and citation:
+    <span dir="ltr">Adam (Kingma &amp; Ba, 2015)</span>
+    شکل <span dir="ltr">3</span>
+  -->
+
+  <section class="refs">
+    <h2>منابع</h2>
+    <ol>
+      <!-- Original-language bibliography. Do not translate entries. -->
+    </ol>
+  </section>
+</body>
+</html>

--- a/scientific-fa-translation/assets/rtl-document.html
+++ b/scientific-fa-translation/assets/rtl-document.html
@@ -25,6 +25,7 @@
     }
     .ltr,
     pre,
+    pre code,
     code,
     kbd,
     samp,
@@ -32,10 +33,13 @@
       direction: ltr;
       unicode-bidi: isolate;
     }
+    pre,
+    pre code {
+      text-align: left;
+    }
     pre {
       overflow-x: auto;
       padding: 0.75rem 1rem;
-      text-align: left;
     }
     code {
       font-family: ui-monospace, "Cascadia Code", "SFMono-Regular", Consolas, monospace;
@@ -46,6 +50,13 @@
     }
     figure {
       margin: 1.5rem 0;
+    }
+    figure img,
+    figure svg {
+      display: block;
+      max-width: 100%;
+      height: auto;
+      transform: none;
     }
     figcaption, caption {
       font-size: 0.95em;
@@ -82,6 +93,15 @@
     Isolate every English term, number cluster, formula, URL, and citation:
     <span dir="ltr">Adam (Kingma &amp; Ba, 2015)</span>
     شکل <span dir="ltr">3</span>
+
+    Code listings must keep dir="ltr" on <pre>, never RTL:
+    <pre dir="ltr"><code>…</code></pre>
+
+    Figures use the original image files; do not mirror:
+    <figure>
+      <img src="figures/fig-3.png" alt="…" width="720" height="420">
+      <figcaption>شکل <span dir="ltr">3</span>. …</figcaption>
+    </figure>
   -->
 
   <section class="refs">

--- a/scientific-fa-translation/assets/rtl-document.html
+++ b/scientific-fa-translation/assets/rtl-document.html
@@ -8,6 +8,10 @@
     :root {
       color-scheme: light dark;
     }
+    @page {
+      size: A4;
+      margin: 2.2cm;
+    }
     body {
       margin: 1.5rem auto;
       max-width: 46rem;

--- a/scientific-fa-translation/assets/rtl-document.tex
+++ b/scientific-fa-translation/assets/rtl-document.tex
@@ -1,0 +1,55 @@
+% !TEX program = xelatex
+% Scientific Persian print template. Compile with XeLaTeX.
+% Load graphicx, hyperref, and geometry BEFORE xepersian.
+\documentclass[a4paper,12pt]{article}
+
+\usepackage{fontspec}
+\usepackage{microtype}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{xcolor}
+\usepackage{fancyvrb}
+\usepackage[a4paper,margin=2.2cm]{geometry}
+\usepackage[unicode=true,colorlinks=true,linkcolor=black,citecolor=black,urlcolor=black]{hyperref}
+
+\usepackage{xepersian}
+
+% Agent: replace these with fonts that exist on the machine (fc-list).
+% Text font must cover Persian. Digit font must be Latin so digits stay Western.
+\settextfont[Ligatures=TeX]{Vazirmatn}
+\setlatintextfont{TeX Gyre Termes}
+\setmonofont[Scale=0.92]{TeX Gyre Cursor}
+\setdigitfont{TeX Gyre Termes}
+
+\newcommand{\en}[1]{\lr{#1}}
+
+\begin{document}
+
+\title{TITLE}
+\author{}
+\date{}
+\maketitle
+
+% Persian prose here. Isolate every English run:
+% الگوریتم \en{Adam} استفاده شد.
+
+% Code: never RTL.
+\begin{latin}
+\begin{Verbatim}[fontsize=\small,frame=single,framesep=6pt,baselinestretch=1.1]
+# listing
+\end{Verbatim}
+\end{latin}
+
+% Figures: original files, not mirrored.
+% \begin{figure}[ht]
+% \centering
+% \includegraphics[width=0.92\linewidth]{figures/fig-3.png}
+% \caption{معماری \en{transformer}.}
+% \end{figure}
+
+\begin{latin}
+\section*{References}
+% Original-language bibliography. Do not translate entries.
+\end{latin}
+
+\end{document}

--- a/scientific-fa-translation/references/glossary.md
+++ b/scientific-fa-translation/references/glossary.md
@@ -1,22 +1,31 @@
 # Glossary
 
-Living list for this skill. The agent must keep English technical terms
-and append new ones here when they appear in a source.
+Living list for this skill. Classify every token against the two
+columns below, then add a row if it is new.
 
 ## Rules
 
-1. If a term is in **Keep English**, output that exact English form
-   inside an LTR isolate. Never substitute a Persian neologism.
-2. If a term is in **Translate**, use the Persian listed here every time.
-3. If a term is missing: keep English, then add a row under the matching
-   domain (or `Unsorted`).
-4. Do not add فرهنگستان coinages unless the user puts them in this file.
+1. **Keep English:** algorithm / library / protocol / product names;
+   acronyms (`API`, `PCR`, `GPU`, `CI`, …); formulas, code, units,
+   statistics (`p`, `n`, `SD`, …); people’s names, journals, DOIs.
+   Output the exact English form in an LTR isolate. Never substitute a
+   Persian neologism.
+2. **Write in Persian:** verbs and sentence structure; general words
+   (روش، نتایج، بررسی); section titles (مقدمه، بحث، …); conceptual
+   explanation for the reader. Never leave those in English.
+3. If a *name* is missing from **Keep English**, keep English and add
+   a row. If a *general word* is missing from **Translate**, write
+   Persian and add a row.
+4. Do not add فرهنگستان coinages for named artifacts unless the user
+   puts them in this file.
 5. Matching is case-sensitive only when the source is (e.g. `BERT` vs
    a generic `bert` identifier in code — follow the source).
 
-## Translate (ordinary scholarly words)
+## Translate (Persian)
 
-These are not “technical terms” in the house-style sense.
+Verbs, structure, general scholarly words, section titles. Conceptual
+prose around a term is also Persian even when the term itself is
+English.
 
 | English | Persian |
 | --- | --- |
@@ -34,33 +43,56 @@ These are not “technical terms” in the house-style sense.
 | appendix | پیوست |
 | paper / article | مقاله |
 | book | کتاب |
+| method | روش |
+| analysis / study (generic) | بررسی |
 | hypothesis | فرضیه |
 | experiment | آزمایش |
 | dataset (generic prose) | مجموعه داده |
 | limitation | محدودیت |
 
-`dataset` as a named corpus (`ImageNet`, `GLUE`) stays English.
+`dataset` as a named corpus (`ImageNet`, `GLUE`) is a product/name and
+stays English.
 
 ## Keep English
 
 Non-exhaustive. Anything of this kind stays English even if unlisted.
 
-### Names and artifacts
+### Algorithms, libraries, protocols, products
 
 | Term | Notes |
 | --- | --- |
 | transformer | architecture / model family |
-| attention | keep when it names the mechanism; prose “توجه” only if non-technical |
 | backpropagation | |
 | gradient descent | |
 | Adam | optimizer name |
-| BERT, GPT, ResNet, YOLO | model names |
+| BERT, GPT, ResNet, YOLO | model / product names |
 | PyTorch, NumPy, TensorFlow | libraries |
-| API, GPU, CPU, TPU, PCR, RMSE, BLEU | acronyms |
-| p, n, M, SD, SE, CI, df | statistics |
+
+### Acronyms
+
+| Term | Notes |
+| --- | --- |
+| API, PCR, GPU, CI | keep as-is |
+| CPU, TPU, RMSE, BLEU | same class |
+
+### Formulas, code, units, statistics
+
+| Term | Notes |
+| --- | --- |
+| p, n, SD | also `M`, `SE`, `df` |
+| SI units | `km`, `ms`, `°C`, … |
+| code / identifiers | never translate listings |
+
+### People, journals, DOIs
+
+| Term | Notes |
+| --- | --- |
+| author names | Latin script |
+| journal / conference names | |
+| DOI, URL | |
 | et al. | inside citations |
 
-### Unsorted
+### Unsorted names
 
 | Term | Notes |
 | --- | --- |

--- a/scientific-fa-translation/references/glossary.md
+++ b/scientific-fa-translation/references/glossary.md
@@ -1,0 +1,69 @@
+# Glossary
+
+Living list for this skill. The agent must keep English technical terms
+and append new ones here when they appear in a source.
+
+## Rules
+
+1. If a term is in **Keep English**, output that exact English form
+   inside an LTR isolate. Never substitute a Persian neologism.
+2. If a term is in **Translate**, use the Persian listed here every time.
+3. If a term is missing: keep English, then add a row under the matching
+   domain (or `Unsorted`).
+4. Do not add فرهنگستان coinages unless the user puts them in this file.
+5. Matching is case-sensitive only when the source is (e.g. `BERT` vs
+   a generic `bert` identifier in code — follow the source).
+
+## Translate (ordinary scholarly words)
+
+These are not “technical terms” in the house-style sense.
+
+| English | Persian |
+| --- | --- |
+| abstract | چکیده |
+| introduction | مقدمه |
+| methods | روش‌ها |
+| results | نتایج |
+| discussion | بحث |
+| conclusion | نتیجه‌گیری |
+| references | منابع |
+| figure | شکل |
+| table | جدول |
+| equation | معادله |
+| section | بخش |
+| appendix | پیوست |
+| paper / article | مقاله |
+| book | کتاب |
+| hypothesis | فرضیه |
+| experiment | آزمایش |
+| dataset (generic prose) | مجموعه داده |
+| limitation | محدودیت |
+
+`dataset` as a named corpus (`ImageNet`, `GLUE`) stays English.
+
+## Keep English
+
+Non-exhaustive. Anything of this kind stays English even if unlisted.
+
+### Names and artifacts
+
+| Term | Notes |
+| --- | --- |
+| transformer | architecture / model family |
+| attention | keep when it names the mechanism; prose “توجه” only if non-technical |
+| backpropagation | |
+| gradient descent | |
+| Adam | optimizer name |
+| BERT, GPT, ResNet, YOLO | model names |
+| PyTorch, NumPy, TensorFlow | libraries |
+| API, GPU, CPU, TPU, PCR, RMSE, BLEU | acronyms |
+| p, n, M, SD, SE, CI, df | statistics |
+| et al. | inside citations |
+
+### Unsorted
+
+| Term | Notes |
+| --- | --- |
+| | |
+
+Add rows as documents are translated.

--- a/scientific-fa-translation/references/pdf-output.md
+++ b/scientific-fa-translation/references/pdf-output.md
@@ -1,0 +1,106 @@
+# Printable PDF output
+
+Cursor chat is **not** the RTL surface. Do not spend effort right-aligning
+the conversation. The deliverable is a printable PDF with maximum bidi
+precision.
+
+Read this file whenever the output is a paper, article, book, or the
+user asks for PDF / چاپ.
+
+## Destination (locked)
+
+Every final PDF is written to:
+
+```text
+~/Documents/books/<slug>.pdf
+```
+
+Expand `~` to the user's home directory (`$HOME/Documents/books`).
+
+1. `mkdir -p "$HOME/Documents/books"`
+2. `<slug>` is a filesystem-safe stem from the source title (ASCII
+   kebab-case is fine, e.g. `attention-is-all-you-need`).
+3. Copy the finished PDF there. That path is what you report in chat.
+4. Re-running the same document may overwrite the same slug. A
+   different work needs a different slug. Never leave the only copy
+   inside the workspace or `/tmp`.
+
+Working files (`.tex`, copied figures, `.html` fallback) may live in
+the workspace. They are not the deliverable.
+
+## Engine order
+
+Use the first that works. Check with `command -v` before compiling.
+
+| Priority | Engine | When |
+| --- | --- | --- |
+| 1 | XeLaTeX + `xepersian` | Default. Most precise Persian print RTL. |
+| 2 | Headless Chromium / Chrome print of the RTL HTML template | If `xelatex` or `xepersian` is missing. |
+| 3 | WeasyPrint on the same HTML | If no TeX and no Chrome. |
+
+Do not use pdfLaTeX. Do not use pandoc's default PDF engine without
+`xepersian` / `bidi` — mixed Persian/English punctuation will be wrong.
+
+If nothing can produce a PDF, say so and list what to install. Still
+write the `.tex` (and figures) so the user can compile later.
+
+## XeLaTeX + xepersian (preferred)
+
+Start from `assets/rtl-document.tex`. Load `hyperref`, `graphicx`, and
+`geometry` **before** `xepersian`.
+
+1. Detect a Persian-capable text font:
+   `fc-list :lang=fa file family | head`
+   Prefer Vazirmatn, then Shabnam, Sahel, Amiri, DejaVu Sans.
+2. Latin serif for `\setlatintextfont` and `\setdigitfont` so digits
+   stay Western (`TeX Gyre Termes`, `Liberation Serif`, `Times New Roman`,
+   `DejaVu Serif`).
+3. Monospace for listings (`TeX Gyre Cursor`, `DejaVu Sans Mono`,
+   `Liberation Mono`).
+4. Substitute those names into the template. Do not ship a PDF whose
+   Persian letters are missing-glyph boxes.
+5. Copy source images next to the `.tex` (e.g. `figures/`) and include
+   them with `\includegraphics`. Same files, order, and aspect as the
+   source. Do not mirror.
+6. Compile with `scripts/build-pdf.sh path/to/doc.tex <slug>`
+   (runs `xelatex` twice, then copies to `~/Documents/books`).
+
+### Bidi mapping
+
+| Role | xepersian |
+| --- | --- |
+| Persian prose | default (RTL) |
+| English term, acronym, citation, URL, number | `\lr{…}` |
+| Code listing | `\begin{latin}…\end{latin}` around `verbatim` / `Verbatim` |
+| Inline code | `\lr{\texttt{…}}` |
+| Math | leave in math mode (LTR) |
+| Bibliography | `latin` environment, source language |
+| Figure | `\includegraphics`, caption in Persian with `\lr` on terms |
+
+Never wrap a listing in an RTL environment. Never `\includegraphics`
+with a horizontal flip.
+
+Western digits: `\setdigitfont` to a Latin font, and `\lr{3}` / `\lr{3.14}`
+for numbers that sit inside Persian sentences.
+
+## Chromium fallback
+
+Only when XeLaTeX is unavailable. Build the HTML from
+`assets/rtl-document.html` with full isolation (see `rtl-bidi.md`),
+using `file://` URLs or relative paths that resolve on disk. Then:
+
+```bash
+mkdir -p "$HOME/Documents/books"
+chromium --headless --disable-gpu --no-pdf-header-footer \
+  --print-to-pdf="$HOME/Documents/books/<slug>.pdf" \
+  "file://$(realpath translation.html)"
+```
+
+Try `chromium`, `chromium-browser`, `google-chrome`, or
+`google-chrome-stable`. A4 via CSS `@page { size: A4; margin: 2.2cm; }`
+(already in the HTML template when printing).
+
+## Chat after success
+
+One short message: what was translated, and the absolute PDF path.
+No attempt at chat RTL. Do not paste the article body into chat.

--- a/scientific-fa-translation/references/rtl-bidi.md
+++ b/scientific-fa-translation/references/rtl-bidi.md
@@ -1,0 +1,122 @@
+# RTL and bidirectional isolation
+
+Precise right-to-left layout is not `text-align: right`. Persian is RTL;
+English terms, digits, math, and URLs are LTR. The Unicode Bidirectional
+Algorithm will misplace punctuation and parentheses unless every LTR run
+is isolated.
+
+This skill writes HTML (`lang="fa"` `dir="rtl"`). Do not rely on Cursor
+chat Markdown for the deliverable.
+
+## Document root
+
+Use `assets/rtl-document.html`. The root must be:
+
+```html
+<html lang="fa" dir="rtl">
+```
+
+CSS on that template:
+
+- `body`: `direction: rtl; unicode-bidi: isolate;`
+- `.ltr`, `pre`, `code`, `kbd`, `samp`, `math`: `direction: ltr; unicode-bidi: isolate;`
+
+Do not set `dir="rtl"` on `pre` or `code`.
+
+## Isolate every LTR run
+
+Wrap each English term, acronym, number cluster, citation key, formula,
+URL, file path, and inline code:
+
+```html
+<span dir="ltr">gradient descent</span>
+<span dir="ltr">Adam (Kingma &amp; Ba, 2015)</span>
+<span dir="ltr">p &lt; 0.05</span>
+<span dir="ltr">https://doi.org/10.0000/example</span>
+```
+
+`<bdi>` is acceptable when the span is a single proper name. Prefer
+`<span dir="ltr">` for anything with parentheses, punctuation, or digits.
+
+A whole English bibliography, code listing, or equation block gets
+`dir="ltr"` on the container, not on every token.
+
+## Wrong vs right
+
+Parentheses and the sentence period are the usual failures.
+
+```html
+<!-- Wrong: parens and the period attach to the English run -->
+الگوریتم Adam (Kingma &amp; Ba, 2015) استفاده شد.
+
+<!-- Right -->
+الگوریتم <span dir="ltr">Adam (Kingma &amp; Ba, 2015)</span> استفاده شد.
+```
+
+```html
+<!-- Wrong: trailing English steals the Persian period -->
+نتایج با RMSE بهتر شد.
+
+<!-- Right -->
+نتایج با <span dir="ltr">RMSE</span> بهتر شد.
+```
+
+If a sentence *ends* on an LTR span and the period still renders on the
+wrong side after isolation, append an RLM (U+200F) immediately after the
+closing `</span>` and before `.`:
+
+```html
+این روش بر پایه <span dir="ltr">backpropagation</span>‏.
+```
+
+Do not scatter RLM/LRM through the file as decoration. Isolation first;
+RLM only for a leftover end-of-sentence period.
+
+## What must stay LTR
+
+| Content | How |
+| --- | --- |
+| Technical English terms | `<span dir="ltr">` |
+| Western digits and numeric ranges | `<span dir="ltr">3.14</span>`, `<span dir="ltr">2017–2024</span>` |
+| Display/inline math | `dir="ltr"` on the math container; keep LaTeX source unchanged |
+| Fenced code / `pre` | `dir="ltr"` (template already does this) |
+| URLs, DOIs, emails | `<span dir="ltr">` or `<a dir="ltr">` |
+| File paths and identifiers | `<span dir="ltr">` |
+| Reference list | a `dir="ltr"` section |
+
+## Headings, lists, tables, figures
+
+- Headings are RTL prose. Isolate LTR fragments inside them the same way.
+- Lists inherit RTL from `body`. Isolate LTR items or fragments per item.
+- Table captions are RTL (`جدول 2. …`). Isolate the number: `جدول <span dir="ltr">2</span>.`
+- Numeric table cells are LTR. Persian prose cells stay RTL.
+- Do not reverse column order unless the user asks.
+- Figure captions: `شکل <span dir="ltr">3</span>. …` Isolate any English
+  term inside the caption.
+
+## Markdown fallback
+
+Only when the user demands Markdown:
+
+```html
+<div lang="fa" dir="rtl">
+
+متن فارسی با <span dir="ltr">transformer</span>.
+
+</div>
+```
+
+GitHub-flavored Markdown will still break some bidi cases. Say so, and
+prefer HTML.
+
+Never reverse English letter order by hand. Never rewrite `(Adam)` as
+`)Adam(` to “fix” RTL.
+
+## Self-check
+
+1. Open the HTML file, not the chat transcript.
+2. Scan every English island: parentheses enclose the English, not the
+   Persian.
+3. Sentence-final periods sit at the right edge of the Persian sentence.
+4. Code and math blocks read left-to-right.
+5. No `ك` / `ي` introduced while editing markup.

--- a/scientific-fa-translation/references/rtl-bidi.md
+++ b/scientific-fa-translation/references/rtl-bidi.md
@@ -5,8 +5,14 @@ English terms, digits, math, and URLs are LTR. The Unicode Bidirectional
 Algorithm will misplace punctuation and parentheses unless every LTR run
 is isolated.
 
-This skill writes HTML (`lang="fa"` `dir="rtl"`). Do not rely on Cursor
-chat Markdown for the deliverable.
+**Cursor chat is not the RTL surface.** Do not right-align the
+conversation. For papers, articles, and books the deliverable is a
+PDF (`references/pdf-output.md`) with maximum bidi precision.
+
+When the print engine is XeLaTeX, isolate with `\lr{…}` / `\en{…}` and
+put listings in a `latin` environment (see `assets/rtl-document.tex`).
+The HTML rules below apply to an explicit HTML ask or the Chromium
+print fallback (`assets/rtl-document.html`).
 
 ## Document root
 
@@ -32,10 +38,20 @@ sessions, and algorithm listings stay left-to-right and left-aligned
 even though the document is Persian.
 
 ```html
-<!-- Required shape -->
+<!-- Required HTML shape (Chromium fallback) -->
 <pre dir="ltr"><code>def fit(x):
     return x @ w
 </code></pre>
+```
+
+```tex
+% Required XeLaTeX shape (PDF)
+\begin{latin}
+\begin{Verbatim}[fontsize=\small,frame=single]
+def fit(x):
+    return x @ w
+\end{Verbatim}
+\end{latin}
 ```
 
 ```html
@@ -66,11 +82,21 @@ URL, file path, and inline code:
 <span dir="ltr">https://doi.org/10.0000/example</span>
 ```
 
+XeLaTeX (PDF):
+
+```tex
+\en{gradient descent}
+\en{Adam (Kingma \& Ba, 2015)}
+\en{p < 0.05}
+```
+
 `<bdi>` is acceptable when the span is a single proper name. Prefer
-`<span dir="ltr">` for anything with parentheses, punctuation, or digits.
+`<span dir="ltr">` (HTML) or `\lr`/`\en` (TeX) for anything with
+parentheses, punctuation, or digits.
 
 A whole English bibliography, code listing, or equation block gets
-`dir="ltr"` on the container, not on every token.
+`dir="ltr"` on the HTML container, or a `latin` environment in TeX,
+not a token-by-token wrap.
 
 ## Wrong vs right
 
@@ -82,6 +108,10 @@ Parentheses and the sentence period are the usual failures.
 
 <!-- Right -->
 الگوریتم <span dir="ltr">Adam (Kingma &amp; Ba, 2015)</span> استفاده شد.
+```
+
+```tex
+الگوریتم \en{Adam (Kingma \& Ba, 2015)} استفاده شد.
 ```
 
 ```html
@@ -111,8 +141,9 @@ RLM only for a leftover end-of-sentence period.
 | Western digits and numeric ranges | `<span dir="ltr">3.14</span>`, `<span dir="ltr">2017–2024</span>` |
 | Display/inline math | `dir="ltr"` on the math container; keep LaTeX source unchanged |
 | Fenced code / `pre` | `dir="ltr"` on `<pre>` plus left-align; never RTL |
-| Inline `code` | `dir="ltr"` on `code` or its wrapper |
-| Images / SVG | unchanged files; do not set `transform` or `dir="rtl"` on `img` |
+| XeLaTeX listing | `latin` + `verbatim` / `Verbatim`; never an RTL wrap |
+| Inline `code` | `dir="ltr"` on `code`, or `\lr{\texttt{…}}` |
+| Images / SVG | unchanged files; no flip; `\includegraphics` or `<img>` |
 | URLs, DOIs, emails | `<span dir="ltr">` or `<a dir="ltr">` |
 | File paths and identifiers | `<span dir="ltr">` |
 | Reference list | a `dir="ltr"` section |

--- a/scientific-fa-translation/references/rtl-bidi.md
+++ b/scientific-fa-translation/references/rtl-bidi.md
@@ -20,8 +20,39 @@ CSS on that template:
 
 - `body`: `direction: rtl; unicode-bidi: isolate;`
 - `.ltr`, `pre`, `code`, `kbd`, `samp`, `math`: `direction: ltr; unicode-bidi: isolate;`
+- `pre`: `text-align: left;` plus `dir="ltr"` on the element
 
-Do not set `dir="rtl"` on `pre` or `code`.
+Never set `dir="rtl"` or `text-align: right` on `pre`, `code`, or a
+wrapper around a listing.
+
+## Code blocks are never RTL
+
+This is a hard rule. Fenced listings, `pre`, file dumps, REPL
+sessions, and algorithm listings stay left-to-right and left-aligned
+even though the document is Persian.
+
+```html
+<!-- Required shape -->
+<pre dir="ltr"><code>def fit(x):
+    return x @ w
+</code></pre>
+```
+
+```html
+<!-- Forbidden -->
+<pre dir="rtl">...</pre>
+<pre style="text-align: right">...</pre>
+<pre>  <!-- inherits RTL from body; still wrong without dir="ltr" -->
+```
+
+Also:
+
+- Do not translate comments, identifiers, or strings inside code.
+- Do not reorder glyphs, reverse indentation, or convert spaces.
+- Inline code in Persian prose is LTR: `<code dir="ltr">fit(x)</code>`
+  or wrap with `<span dir="ltr"><code>…</code></span>`.
+- Markdown fallback: do not leave a bare ` ``` ` fence inside a
+  `dir="rtl"` div. Wrap it in `<pre dir="ltr"><code>`.
 
 ## Isolate every LTR run
 
@@ -79,7 +110,9 @@ RLM only for a leftover end-of-sentence period.
 | Technical English terms | `<span dir="ltr">` |
 | Western digits and numeric ranges | `<span dir="ltr">3.14</span>`, `<span dir="ltr">2017–2024</span>` |
 | Display/inline math | `dir="ltr"` on the math container; keep LaTeX source unchanged |
-| Fenced code / `pre` | `dir="ltr"` (template already does this) |
+| Fenced code / `pre` | `dir="ltr"` on `<pre>` plus left-align; never RTL |
+| Inline `code` | `dir="ltr"` on `code` or its wrapper |
+| Images / SVG | unchanged files; do not set `transform` or `dir="rtl"` on `img` |
 | URLs, DOIs, emails | `<span dir="ltr">` or `<a dir="ltr">` |
 | File paths and identifiers | `<span dir="ltr">` |
 | Reference list | a `dir="ltr"` section |
@@ -93,6 +126,17 @@ RLM only for a leftover end-of-sentence period.
 - Do not reverse column order unless the user asks.
 - Figure captions: `شکل <span dir="ltr">3</span>. …` Isolate any English
   term inside the caption.
+- The `<img>` / `<svg>` itself is not RTL content. Do not mirror it
+  (`transform: scaleX(-1)` is forbidden). Place it in the same
+  relative position as the source. Width/height follow the source
+  aspect ratio.
+
+```html
+<figure>
+  <img src="figures/fig-3.png" alt="…" width="720" height="420">
+  <figcaption>شکل <span dir="ltr">3</span>. معماری <span dir="ltr">transformer</span>.</figcaption>
+</figure>
+```
 
 ## Markdown fallback
 
@@ -103,11 +147,19 @@ Only when the user demands Markdown:
 
 متن فارسی با <span dir="ltr">transformer</span>.
 
+<pre dir="ltr"><code>print(x)</code></pre>
+
+<figure>
+  <img src="figures/fig-3.png" alt="…" width="720" height="420">
+  <figcaption>شکل <span dir="ltr">3</span>. …</figcaption>
+</figure>
+
 </div>
 ```
 
 GitHub-flavored Markdown will still break some bidi cases. Say so, and
-prefer HTML.
+prefer HTML. A bare Markdown fence inside a RTL container is not
+enough; wrap listings in `<pre dir="ltr">`.
 
 Never reverse English letter order by hand. Never rewrite `(Adam)` as
 `)Adam(` to “fix” RTL.
@@ -118,5 +170,7 @@ Never reverse English letter order by hand. Never rewrite `(Adam)` as
 2. Scan every English island: parentheses enclose the English, not the
    Persian.
 3. Sentence-final periods sit at the right edge of the Persian sentence.
-4. Code and math blocks read left-to-right.
+4. Code blocks are LTR, left-aligned, and optically identical to the
+   source listing. Images are the source files, unmirrored, in source
+   order.
 5. No `ك` / `ي` introduced while editing markup.

--- a/scientific-fa-translation/references/scientific-style.md
+++ b/scientific-fa-translation/references/scientific-style.md
@@ -87,8 +87,8 @@ Do not localize the numeral.
 The translation must *show* the same figures the source shows.
 
 - Copy the original files (PNG, JPEG, SVG, PDF page extract, etc.).
-  Point `img src` at those copies. Do not redraw, screenshot-replace,
-  or generate a new figure.
+  Point `\includegraphics` or `img src` at those copies. Do not redraw,
+  screenshot-replace, or generate a new figure.
 - Keep document order: if Figure 3 follows the paragraph that cites
   it, the translation does the same.
 - Keep subfigure layout (`a`/`b`/`c`), aspect ratio, and resolution.
@@ -100,8 +100,9 @@ The translation must *show* the same figures the source shows.
 - Translate only the caption and any prose that refers to the figure.
 - `alt` may be a short Persian description for accessibility; it
   must not replace the image.
-- If an image file is missing or unreadable, insert a visible HTML
-  comment and tell the user. Do not invent a substitute figure.
+- If an image file is missing or unreadable, insert a visible comment
+  in the `.tex` or HTML and tell the user. Do not invent a substitute
+  figure.
 
 ## Citations in the body
 

--- a/scientific-fa-translation/references/scientific-style.md
+++ b/scientific-fa-translation/references/scientific-style.md
@@ -53,7 +53,9 @@ Leave unchanged (aside from LTR markup):
 - Bibliography entries: authors, article titles, journals, proceedings,
   publishers, years, DOIs, URLs
 - Author names in the body (Latin script)
-- Code, commands, identifiers, file names
+- Code, commands, identifiers, file names (listings stay LTR; see
+  `rtl-bidi.md`)
+- Raster and vector figures: same files as the source
 - Mathematics and chemical formulas
 - Standard statistical symbols (`n`, `p`, `M`, `SD`, `SE`, `CI`, `df`)
 - Product, library, protocol, and model names
@@ -63,7 +65,7 @@ Translate:
 
 - Body prose, including the abstract
 - Section titles (`Introduction` → `مقدمه`, and so on)
-- Figure and table captions (not the identifiers)
+- Figure and table captions (not the identifiers, not the image files)
 - Footnotes that explain the text
 - Quotes from the source, in the same scientific register
 
@@ -79,6 +81,27 @@ Translate:
 | Theorem / Lemma / Proof | قضیه / لم / اثبات — keep the number LTR |
 
 Do not localize the numeral.
+
+## Images and figures
+
+The translation must *show* the same figures the source shows.
+
+- Copy the original files (PNG, JPEG, SVG, PDF page extract, etc.).
+  Point `img src` at those copies. Do not redraw, screenshot-replace,
+  or generate a new figure.
+- Keep document order: if Figure 3 follows the paragraph that cites
+  it, the translation does the same.
+- Keep subfigure layout (`a`/`b`/`c`), aspect ratio, and resolution.
+  Do not crop, pad, or scale in a way that changes what is visible.
+- Do not mirror or rotate for RTL. Plots, UI captures, anatomy, and
+  diagrams stay optically identical to the source.
+- Labels *inside* the image (axis text, legends baked into a PNG)
+  stay as in the source. Do not edit pixels to Persianize them.
+- Translate only the caption and any prose that refers to the figure.
+- `alt` may be a short Persian description for accessibility; it
+  must not replace the image.
+- If an image file is missing or unreadable, insert a visible HTML
+  comment and tell the user. Do not invent a substitute figure.
 
 ## Citations in the body
 

--- a/scientific-fa-translation/references/scientific-style.md
+++ b/scientific-fa-translation/references/scientific-style.md
@@ -1,0 +1,118 @@
+# Academic Persian style
+
+House style for this skill. It is stricter than general translation:
+faithfulness to the source science first, then readable فارسی معیار.
+
+## Register
+
+- Formal written Persian. No spoken reductions: not `میشه`, `می‌خواد`,
+  `چونکه` as a default, `اصلاً` as filler.
+- Prefer clear scientific prose over calques. Do not copy English
+  word order when it produces unreadable Persian.
+- Keep the author's epistemic stance. `may` / `might` / `suggest` /
+  `appear to` / `remain unknown` must not become certainty.
+- Do not add background, examples, or conclusions the source lacks.
+- Do not drop hedges, limitations, negative results, or sample-size
+  caveats to sound smoother.
+
+## Orthography
+
+- Encoding: UTF-8.
+- Persian letters: `ک` not `ك`, `ی` not `ي`. Normalize Arabic forms if
+  they appear in a draft.
+- نیم‌فاصله (U+200C) where Persian orthography requires it, including
+  `می‌شود`, `می‌توان`, `نمی‌کند`, `شده‌اند`, and standard adjectival
+  compounds.
+- Punctuation: `،` `؛` `؟` `!` `«»`. Use `…` sparingly. Do not use Latin
+  `,` `;` `?` or `"` for Persian prose.
+- Scientific numbers stay Western digits: `3.14`, `2e-5`, `95%`. Do not
+  convert to `۳٫۱۴`.
+- Decimal point stays `.` inside numbers. Persian `٫` is not used here.
+- SI units stay SI (`km`, `ms`, `°C`). Do not convert unit systems.
+
+## Terminology
+
+Policy lives in `glossary.md`. Summary:
+
+- Specialized terms, names, and acronyms stay English, LTR-isolated.
+- Do not coin or apply فرهنگستان equivalents unless the glossary
+  already lists that Persian form as required.
+- Ordinary method/result language is Persian (`روش`, `نتایج`, `بررسی`).
+- One English form per concept for the whole document.
+- On first use, do not add a gloss like `نزول گرادیان (gradient descent)`
+  unless the glossary says to.
+
+If a term is genuinely common Persian in that field and already in the
+glossary with a Persian form, follow the glossary. When unsure, keep
+English and ask.
+
+## What not to translate
+
+Leave unchanged (aside from LTR markup):
+
+- Bibliography entries: authors, article titles, journals, proceedings,
+  publishers, years, DOIs, URLs
+- Author names in the body (Latin script)
+- Code, commands, identifiers, file names
+- Mathematics and chemical formulas
+- Standard statistical symbols (`n`, `p`, `M`, `SD`, `SE`, `CI`, `df`)
+- Product, library, protocol, and model names
+- Binomial species names and gene symbols
+
+Translate:
+
+- Body prose, including the abstract
+- Section titles (`Introduction` → `مقدمه`, and so on)
+- Figure and table captions (not the identifiers)
+- Footnotes that explain the text
+- Quotes from the source, in the same scientific register
+
+## Cross-references and labels
+
+| Source | Persian |
+| --- | --- |
+| Figure 3 | شکل 3 |
+| Table 2 | جدول 2 |
+| Equation (4) | معادله (4) |
+| Section 3.2 | بخش 3.2 |
+| Appendix A | پیوست A |
+| Theorem / Lemma / Proof | قضیه / لم / اثبات — keep the number LTR |
+
+Do not localize the numeral.
+
+## Citations in the body
+
+Keep citation keys in source form, isolated as LTR:
+
+- `(Smith et al., 2021)` stays `(Smith et al., 2021)`
+- `[12]` stays `[12]`
+- `DOI` links stay URLs
+
+Do not translate `et al.` Do not convert Harvard to Vancouver or the
+reverse.
+
+## Headings (typical article)
+
+Use these unless the source uses a different scheme; then stay parallel.
+
+| English | Persian |
+| --- | --- |
+| Abstract | چکیده |
+| Introduction | مقدمه |
+| Related work | کارهای مرتبط |
+| Methods / Materials and methods | روش‌ها / مواد و روش‌ها |
+| Results | نتایج |
+| Discussion | بحث |
+| Conclusion | نتیجه‌گیری |
+| Acknowledgments | سپاسگزاری |
+| References / Bibliography | منابع |
+| Appendix | پیوست |
+
+## Ambiguity
+
+If a pronoun, scope of negation, or technical reading would change the
+science, stop and ask. Do not pick the “more fluent” reading.
+
+If the source is truncated, OCR-garbled, or a formula is unreadable,
+leave a short HTML comment at that spot and tell the user. Do not
+invent the missing science.

--- a/scientific-fa-translation/references/scientific-style.md
+++ b/scientific-fa-translation/references/scientific-style.md
@@ -32,42 +32,50 @@ faithfulness to the source science first, then readable فارسی معیار.
 
 ## Terminology
 
-Policy lives in `glossary.md`. Summary:
+Policy lives in `glossary.md`. Two columns only:
 
-- Specialized terms, names, and acronyms stay English, LTR-isolated.
-- Do not coin or apply فرهنگستان equivalents unless the glossary
-  already lists that Persian form as required.
-- Ordinary method/result language is Persian (`روش`, `نتایج`, `بررسی`).
-- One English form per concept for the whole document.
-- On first use, do not add a gloss like `نزول گرادیان (gradient descent)`
-  unless the glossary says to.
+**Keep English** (LTR-isolated). Do not coin فرهنگستان equivalents.
 
-If a term is genuinely common Persian in that field and already in the
-glossary with a Persian form, follow the glossary. When unsure, keep
-English and ask.
+- Algorithm, library, protocol, and product names
+- Acronyms (`API`, `PCR`, `GPU`, `CI`, and the same class)
+- Formulas, code, units, statistics (`p`, `n`, `SD`, …)
+- People’s names, journal names, DOIs (and bibliography entries)
+
+**Write in Persian.** Do not leave these in English.
+
+- Verbs and sentence structure
+- General words: روش، نتایج، بررسی
+- Section titles: مقدمه، بحث، …
+- Conceptual explanation for the reader (the prose around a term)
+
+One English form per named concept for the whole document. On first
+use, do not add a gloss like `نزول گرادیان (gradient descent)` unless
+the glossary says to.
+
+When unsure, classify against those two columns. Do not default a
+general word to English. Ask only if the class is still unclear.
 
 ## What not to translate
 
 Leave unchanged (aside from LTR markup):
 
-- Bibliography entries: authors, article titles, journals, proceedings,
-  publishers, years, DOIs, URLs
-- Author names in the body (Latin script)
-- Code, commands, identifiers, file names (listings stay LTR; see
-  `rtl-bidi.md`)
+- Names of algorithms, libraries, protocols, and products
+- Acronyms (`API`, `PCR`, `GPU`, `CI`, …)
+- Formulas, code, units, statistical symbols (`p`, `n`, `SD`, …)
+- People’s names; journal, conference, and DOI/URL strings
+- Bibliography entries: authors, article titles, journals, years
 - Raster and vector figures: same files as the source
-- Mathematics and chemical formulas
-- Standard statistical symbols (`n`, `p`, `M`, `SD`, `SE`, `CI`, `df`)
-- Product, library, protocol, and model names
-- Binomial species names and gene symbols
 
-Translate:
+## What must be Persian
 
-- Body prose, including the abstract
-- Section titles (`Introduction` → `مقدمه`, and so on)
-- Figure and table captions (not the identifiers, not the image files)
-- Footnotes that explain the text
-- Quotes from the source, in the same scientific register
+Translate; do not keep the English wording:
+
+- Verbs and clause structure
+- General scholarly words (`method` → روش, `results` → نتایج,
+  `analysis` / `study` → بررسی)
+- Section titles (`Introduction` → مقدمه, `Discussion` → بحث, …)
+- Conceptual explanation for the reader, including abstract, captions
+  (not image files), footnotes, and quotes in the scientific register
 
 ## Cross-references and labels
 

--- a/scientific-fa-translation/scripts/build-pdf.sh
+++ b/scientific-fa-translation/scripts/build-pdf.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Compile a XeLaTeX document and copy the PDF to ~/Documents/books.
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: build-pdf.sh <file.tex> [slug]" >&2
+  exit 2
+fi
+
+tex=$1
+if [[ ! -f "$tex" ]]; then
+  echo "build-pdf.sh: not a file: $tex" >&2
+  exit 1
+fi
+
+tex_dir=$(cd "$(dirname "$tex")" && pwd)
+tex_base=$(basename "$tex")
+stem=${2:-${tex_base%.tex}}
+dest_dir="${HOME}/Documents/books"
+dest="${dest_dir}/${stem}.pdf"
+
+if ! command -v xelatex >/dev/null 2>&1; then
+  echo "build-pdf.sh: xelatex not found" >&2
+  exit 1
+fi
+
+mkdir -p "$dest_dir"
+cd "$tex_dir"
+
+xelatex -interaction=nonstopmode -halt-on-error "$tex_base"
+xelatex -interaction=nonstopmode -halt-on-error "$tex_base"
+
+pdf="${tex_base%.tex}.pdf"
+if [[ ! -f "$pdf" ]]; then
+  echo "build-pdf.sh: expected PDF missing: ${tex_dir}/${pdf}" >&2
+  exit 1
+fi
+
+cp -f "$pdf" "$dest"
+echo "$dest"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the first personal Cursor skill: academic English → Persian translation.

## Why this layout

This repo is meant to be cloned to `~/.cursor/skills`. Cursor walks that directory recursively and loads any folder that contains a `SKILL.md`, so the skill lives at the repo root (`scientific-fa-translation/`), not under a nested `.cursor/skills/`.

## Skill: `scientific-fa-translation`

Invoke with `/scientific-fa-translation`, or by asking to translate a paper/article/book into Persian.

Locked defaults (override only when asked):

- Formal scientific Persian; no colloquial forms
- **Keep English:** algorithm / library / protocol / product names; acronyms (`API`, `PCR`, `GPU`, `CI`); formulas, code, units, statistics (`p`, `n`, `SD`); people’s names, journals, DOIs
- **Write in Persian:** verbs and sentence structure; general words (روش، نتایج، بررسی); section titles (مقدمه، بحث); conceptual explanation for the reader
- Cursor chat is a short pointer, not the RTL surface
- Default deliverable is a printable PDF with maximum bidi precision (XeLaTeX + `xepersian`; Chromium print of the RTL HTML as fallback)
- Final PDF always saved at `~/Documents/books/<slug>.pdf`
- Western digits; captions like `شکل 3`
- Translate abstract and footnotes; do not translate the bibliography
- Code blocks are always LTR and left-aligned. Never RTL
- Images are the original files, in source order and size. Do not mirror, crop, redraw, or drop them. Translate captions only
- Ask on scientific ambiguity instead of guessing

Supporting files:

- `references/scientific-style.md` — register, orthography, citations, figures
- `references/rtl-bidi.md` — bidirectional isolation, code-block LTR, image placement
- `references/pdf-output.md` — PDF engine order, `~/Documents/books` destination
- `references/glossary.md` — keep-English vs write-Persian list that grows per document
- `assets/rtl-document.tex` — XeLaTeX/`xepersian` print template
- `assets/rtl-document.html` — HTML / Chromium-print fallback
- `scripts/build-pdf.sh` — compile and copy the PDF into `~/Documents/books`

The skill description explicitly excludes coding, commits, UI copy, and casual Persian chat so it does not hijack normal work after a global install.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e931297-66bc-4fbe-b46d-f01692b37408?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e931297-66bc-4fbe-b46d-f01692b37408&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

