### PR TITLE
docs: clone anywhere, no skill symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 # skills
 
-Personal [Cursor Agent Skills](https://cursor.com/docs/skills). Each skill
-lives in `.cursor/skills/<name>/SKILL.md` so it loads in this workspace.
-
-To use the same skills in every project, link them into the user skills
-directory:
+Personal [Cursor Agent Skills](https://cursor.com/docs/skills). Clone this
+repository anywhere, open **this folder** in Cursor, and work. Skills live
+in `.cursor/skills/` so they load with the repo. No install step, no
+symlinks, no copy into `~/.cursor`.
 
 ```bash
-git clone git@github.com:isArman/skills.git ~/src/skills
-mkdir -p ~/.cursor/skills
-ln -s ~/src/skills/.cursor/skills/scientific-fa-translation \
-  ~/.cursor/skills/scientific-fa-translation
+git clone git@github.com:isArman/skills.git
 ```
 
-After pulling, reload Cursor or type `/scientific-fa-translation` in Agent
-chat to confirm the skill is visible.
+Open the cloned directory in Cursor. Type `/scientific-fa-translation` in
+Agent chat. After `git pull`, reload the window if a new skill does not
+appear.
 
 ## Skills
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Project skills already live in `.cursor/skills/`, which Cursor loads whenever this repository is the open workspace. Clone the repo anywhere, open that folder, and `/scientific-fa-translation` is available.

This drops the README instructions to symlink into `~/.cursor/skills`. No extra install step.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e931297-66bc-4fbe-b46d-f01692b37408?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e931297-66bc-4fbe-b46d-f01692b37408&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

