### PR TITLE
fix: load translation skill in new chats without slash

### DIFF
--- a/.cursor/rules/scientific-fa-translation.mdc
+++ b/.cursor/rules/scientific-fa-translation.mdc
@@ -1,0 +1,14 @@
+---
+description: Load scientific Persian translation skill for papers, RTL, and PDFs.
+alwaysApply: true
+---
+
+This workspace ships `.cursor/skills/scientific-fa-translation/SKILL.md`.
+
+If the user asks to translate a scientific document, article, or book into
+Persian, or mentions RTL, راست‌چین, PDF, or چاپ, read that SKILL.md and
+follow it. Do not wait for a slash command. Cursor chat is not the RTL
+surface; write a PDF to `~/Documents/books`.
+
+Skip this for coding, commits, UI copy, literary translation, and casual
+Persian chat.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Skills
+
+This repository is a Cursor workspace. Project skills are in
+`.cursor/skills/`. Clone it anywhere, open this folder, and work.
+
+When the user wants to translate a paper, article, book, or technical
+document into scientific Persian — or asks for RTL, چاپ, or a PDF —
+read and follow `.cursor/skills/scientific-fa-translation/SKILL.md`
+before producing output. Do this even if `/scientific-fa-translation`
+is missing from the slash menu.
+
+Do not use that skill for coding, commits, UI copy, or casual chat.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ symlinks, no copy into `~/.cursor`.
 git clone git@github.com:isArman/skills.git
 ```
 
-Open the cloned directory in Cursor. Type `/scientific-fa-translation` in
-Agent chat. After `git pull`, reload the window if a new skill does not
-appear.
+Open the cloned directory in Cursor as the workspace. In Agent chat,
+ask to translate (or type `/scientific-fa-translation`). If the slash
+menu is empty — common on Cloud Agent follow-ups — write it in prose:
+“use the scientific-fa-translation skill”.
+
+After `git pull` on a new machine, start a **new** Agent on branch
+`main`. Follow-ups in an already-running Cloud Agent do not reliably
+reload project skills.
 
 ## Skills
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Agents often do not show `/scientific-fa-translation` in the slash menu on follow-up turns (known Cursor Agents Window bug). This repo’s first Cloud Agent also started on an old branch where the skill was not under `.cursor/skills/`, so discovery never ran.

Adds:

- `AGENTS.md` — tells the agent to read the skill when the user asks to translate
- `.cursor/rules/scientific-fa-translation.mdc` (`alwaysApply: true`) — same bootstrap without a slash command

Open a **new** Cloud Agent on `main` (not a follow-up on the old run). If `/` is empty, say “use the scientific-fa-translation skill”.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e931297-66bc-4fbe-b46d-f01692b37408?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e931297-66bc-4fbe-b46d-f01692b37408&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

