### PR TITLE
fix: close HTML PDF fallback gaps and joined-LTR bidi traps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ the output path. It is not the RTL surface.
 
 **Deliverable.** A printable PDF at `~/Documents/books/<slug>.pdf`,
 created if needed. Preferred engine: XeLaTeX + `xepersian`
-(`assets/rtl-document.tex`). Fallback: Chromium print of the RTL HTML
-template. HTML is produced only when asked for, or as that fallback.
+(`assets/rtl-document.tex`). Fallbacks: Chromium print of the RTL HTML
+template, then WeasyPrint on the same HTML. HTML is produced only when
+asked for, or as that fallback. Embed Vazirmatn Regular/Bold (not UI-FD)
+via `@font-face` when the font is not installed on the system.
 
 **Keep English** (LTR-isolated; no فرهنگستان coinages):
 
@@ -64,6 +66,7 @@ scientific-fa-translation/
   references/pdf-output.md
   references/glossary.md
   scripts/build-pdf.sh
+  scripts/fetch-vazirmatn.sh
 ```
 
 ## License

--- a/scientific-fa-translation/SKILL.md
+++ b/scientific-fa-translation/SKILL.md
@@ -39,7 +39,7 @@ Override only when the user says so.
 | First mention | Named English terms: English only, no gloss, unless `references/glossary.md` says so. |
 | Output | Printable PDF at `~/Documents/books/<slug>.pdf`. Chat is a short pointer, not RTL. |
 | PDF RTL | Maximum precision via XeLaTeX + `xepersian`. See `references/pdf-output.md`. |
-| HTML | Only if the user asks for HTML, or as the Chromium-print fallback. |
+| HTML | Only if the user asks for HTML, or as the Chromium / WeasyPrint fallback. |
 | Digits | Western (`3.14`, not `۳٫۱۴`). |
 | Figures/tables | `شکل 3`, `جدول 2` — label translated, number unchanged. |
 | Images | Same files, order, size, and placement as the source. Do not mirror, crop, redraw, or drop. |
@@ -68,7 +68,8 @@ conversation and do not paste the article into chat.
 6. RTL pass on the print source (`.tex` with `\lr` / `latin`, or HTML
    isolation if falling back). See `references/rtl-bidi.md`.
 7. Consistency pass: same English term for the same concept throughout.
-8. Compile the PDF to `~/Documents/books/<slug>.pdf`. Run the checklist.
+8. Compile the PDF to `~/Documents/books/<slug>.pdf` with
+   `scripts/build-pdf.sh` (`.tex` or `.html`). Run the checklist.
 
 If the user asks for HTML only, use `assets/rtl-document.html`. If they
 ask for Markdown, wrap the body in `<div lang="fa" dir="rtl">` and still
@@ -126,6 +127,9 @@ On the **PDF** (non-negotiable when producing a printable file):
 - Prefer XeLaTeX + `xepersian` from `assets/rtl-document.tex`.
 - Isolate every English term, number cluster, formula, URL, and inline
   code with `\lr{…}` (or `<span dir="ltr">` on the HTML fallback).
+  Slash-, arrow-, or parenthesis-joined English (`OP_IF/OP_NOTIF`,
+  `STARTED -> LOCKED_IN`, `1.0.1 (2026-08-09)`) is **one** isolate, not
+  two spans with punctuation between them.
 - Code listings are LTR and left-aligned: `latin` + `verbatim` /
   `Verbatim`, or `<pre dir="ltr">`. Never RTL, never right-aligned.
 - Math stays LTR. Do not reverse English letters or hand-flip
@@ -151,9 +155,14 @@ directory if needed. Report that absolute path in chat.
 5. Bibliography in a `latin` section, source language.
 6. `scripts/build-pdf.sh path/to/doc.tex <slug>`
    → `$HOME/Documents/books/<slug>.pdf`.
+   If `xelatex` is missing, still write the `.tex`, then compile
+   `assets/rtl-document.html` (filled in) with the same script:
+   `scripts/build-pdf.sh path/to/doc.html <slug>`.
+   Embed Vazirmatn via `@font-face` (`scripts/fetch-vazirmatn.sh`).
+   Do not use the UI-FD / Farsi-digits cut of that family.
 
 HTML (`assets/rtl-document.html`) is only for an explicit HTML ask or
-the Chromium-print fallback in `references/pdf-output.md`.
+the Chromium / WeasyPrint fallback in `references/pdf-output.md`.
 
 ## Quality checklist
 
@@ -164,6 +173,8 @@ the Chromium-print fallback in `references/pdf-output.md`.
 - [ ] Citations, equations, numbers, and units unchanged
 - [ ] `ک`/`ی` Persian; نیم‌فاصله present; no colloquial forms
 - [ ] Every mixed LTR run is isolated (`\lr` / `dir="ltr"`); punctuation attaches correctly
+- [ ] Joined English (`a/b`, `a -> b`, `1.0.1 (2026-08-09)`) is a single isolate
+- [ ] HTML-engine PDFs embed a real `fa` font (not missing-glyph boxes); digits stay Western
 - [ ] Every code block is LTR, left-aligned, source text unchanged
 - [ ] Every source image is present, unmirrored, in the same place
 - [ ] Bibliography, DOIs, and URLs not translated

--- a/scientific-fa-translation/assets/rtl-document.html
+++ b/scientific-fa-translation/assets/rtl-document.html
@@ -12,6 +12,20 @@
       size: A4;
       margin: 2.2cm;
     }
+    /* Copy Vazirmatn-Regular.ttf and Vazirmatn-Bold.ttf into fonts/
+       next to this file (scripts/fetch-vazirmatn.sh fonts). Never UI-FD. */
+    @font-face {
+      font-family: "Vazirmatn";
+      src: url("fonts/Vazirmatn-Regular.ttf") format("truetype");
+      font-weight: 400;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: "Vazirmatn";
+      src: url("fonts/Vazirmatn-Bold.ttf") format("truetype");
+      font-weight: 700;
+      font-style: normal;
+    }
     body {
       margin: 1.5rem auto;
       max-width: 46rem;
@@ -96,6 +110,8 @@
   <!--
     Isolate every English term, number cluster, formula, URL, and citation:
     <span dir="ltr">Adam (Kingma &amp; Ba, 2015)</span>
+    <span dir="ltr">OP_IF/OP_NOTIF</span>
+    <span dir="ltr">1.0.1 (2026-08-09)</span>
     شکل <span dir="ltr">3</span>
 
     Code listings must keep dir="ltr" on <pre>, never RTL:

--- a/scientific-fa-translation/references/glossary.md
+++ b/scientific-fa-translation/references/glossary.md
@@ -49,6 +49,32 @@ English.
 | experiment | آزمایش |
 | dataset (generic prose) | مجموعه داده |
 | limitation | محدودیت |
+| specification | مشخصات |
+| copyright | حق نشر |
+| motivation | انگیزه |
+| rationale | استدلال |
+| tradeoffs | بده‌بستان‌ها |
+| alternatives | جایگزین‌ها |
+| backwards compatibility | سازگاری پس‌رو |
+| reference implementation | پیاده‌سازی مرجع |
+| test vectors | بردارهای آزمون |
+| deployment | استقرار |
+| credits | سپاسگزاری |
+| changelog | تاریخچه تغییرات |
+| consensus | اجماع |
+| soft fork / softfork | فورک نرم |
+| hard fork / hardfork | فورک سخت |
+| node | گره |
+| miner | استخراج‌کننده |
+| transaction | تراکنش |
+| block | بلوک |
+| fee | کارمزد |
+| spam | هرزنامه |
+| policy | سیاست |
+| activation | فعال‌سازی |
+| invalid | نامعتبر |
+| grandfathering | معافیت عطف‌به‌ماسبق |
+| steganography | پنهان‌نگاری |
 
 `dataset` as a named corpus (`ImageNet`, `GLUE`) is a product/name and
 stays English.
@@ -67,6 +93,16 @@ Non-exhaustive. Anything of this kind stays English even if unlisted.
 | Adam | optimizer name |
 | BERT, GPT, ResNet, YOLO | model / product names |
 | PyTorch, NumPy, TensorFlow | libraries |
+| Bitcoin | network / product |
+| Taproot, Tapleaf, Tapscript, Taptree | Bitcoin script / output family |
+| Segwit | protocol name |
+| BitVM | protocol / product |
+| Miniscript | compiler / language name |
+| Nostr, IPFS, BitTorrent | products / protocols |
+| inscription | named embedding technique |
+| pay-to-contract | named commitment scheme |
+| blobspace | named scheme |
+| GetBlockTemplate, GBT | protocol / API name |
 
 ### Acronyms
 
@@ -74,6 +110,10 @@ Non-exhaustive. Anything of this kind stays English even if unlisted.
 | --- | --- |
 | API, PCR, GPU, CI | keep as-is |
 | CPU, TPU, RMSE, BLEU | same class |
+| BIP, UTXO, P2WPKH, P2WSH, P2TR, P2A | Bitcoin |
+| NUMS | nothing-up-my-sleeve |
+| RAM | |
+| OP_RETURN, OP_PUSHDATA, OP_SUCCESS, OP_IF, OP_NOTIF | opcodes |
 
 ### Formulas, code, units, statistics
 
@@ -82,6 +122,8 @@ Non-exhaustive. Anything of this kind stays English even if unlisted.
 | p, n, SD | also `M`, `SE`, `df` |
 | SI units | `km`, `ms`, `°C`, … |
 | code / identifiers | never translate listings |
+| scriptPubKey, scriptSig, redeemScript | identifiers |
+| witness, annex, control block, keypath | named stack / spend artifacts |
 
 ### People, journals, DOIs
 
@@ -91,11 +133,16 @@ Non-exhaustive. Anything of this kind stays English even if unlisted.
 | journal / conference names | |
 | DOI, URL | |
 | et al. | inside citations |
+| Dathon Ohm | BIP 110 author |
+| Luke-Jr | credit |
 
 ### Unsorted names
 
 | Term | Notes |
 | --- | --- |
-| | |
+| BSD-3-Clause | license |
+| reduced_data | BIP 9 deployment name |
+| LOCKED_IN, ACTIVE, DEFINED, STARTED, EXPIRED, FAILED | BIP 9 states |
+| BIP9, BIP8, BIP16, BIP141, BIP341, BIP342, BIP433, BIP-3 | BIP identifiers |
 
 Add rows as documents are translated.

--- a/scientific-fa-translation/references/pdf-output.md
+++ b/scientific-fa-translation/references/pdf-output.md
@@ -31,6 +31,8 @@ the workspace. They are not the deliverable.
 ## Engine order
 
 Use the first that works. Check with `command -v` before compiling.
+`scripts/build-pdf.sh` walks this list: XeLaTeX for `.tex`, then Chromium,
+then WeasyPrint for `.html` (or a sibling `.html` if `xelatex` is missing).
 
 | Priority | Engine | When |
 | --- | --- | --- |
@@ -64,6 +66,7 @@ Start from `assets/rtl-document.tex`. Load `hyperref`, `graphicx`, and
    source. Do not mirror.
 6. Compile with `scripts/build-pdf.sh path/to/doc.tex <slug>`
    (runs `xelatex` twice, then copies to `~/Documents/books`).
+   If `xelatex` is missing, the same script accepts `path/to/doc.html`.
 
 ### Bidi mapping
 
@@ -83,11 +86,32 @@ with a horizontal flip.
 Western digits: `\setdigitfont` to a Latin font, and `\lr{3}` / `\lr{3.14}`
 for numbers that sit inside Persian sentences.
 
+## HTML font (Chromium and WeasyPrint)
+
+The HTML template names Vazirmatn. A family name is not enough: if that
+font is not installed, the PDF will show missing-glyph boxes.
+
+1. Detect a Persian-capable font: `fc-list :lang=fa family | head`.
+2. If Vazirmatn (or another `fa` face) is not installed, run
+   `scripts/fetch-vazirmatn.sh path/to/fonts` next to the HTML file.
+   Copy **Regular** and **Bold** only. Never the `UI-FD` / Farsi-digits
+   cut — that family draws `۳٫۱۴` and violates the Western-digit lock.
+3. Keep the template's `@font-face` `url("fonts/Vazirmatn-Regular.ttf")`
+   (and Bold) so Chromium and WeasyPrint embed the files. Relative URLs
+   must resolve from the HTML directory; `build-pdf.sh` `cd`s there.
+4. Latin fallback for `pre`/`code`: DejaVu Sans Mono or Liberation Mono.
+
 ## Chromium fallback
 
-Only when XeLaTeX is unavailable. Build the HTML from
-`assets/rtl-document.html` with full isolation (see `rtl-bidi.md`),
-using `file://` URLs or relative paths that resolve on disk. Then:
+Only when XeLaTeX is unavailable. Fill `assets/rtl-document.html` with
+full isolation (see `rtl-bidi.md`), using `file://` URLs or relative
+paths that resolve on disk. Prefer:
+
+```bash
+scripts/build-pdf.sh path/to/translation.html <slug>
+```
+
+Manual equivalent:
 
 ```bash
 mkdir -p "$HOME/Documents/books"
@@ -99,6 +123,19 @@ chromium --headless --disable-gpu --no-pdf-header-footer \
 Try `chromium`, `chromium-browser`, `google-chrome`, or
 `google-chrome-stable`. A4 via CSS `@page { size: A4; margin: 2.2cm; }`
 (already in the HTML template when printing).
+
+## WeasyPrint fallback
+
+When there is no XeLaTeX and no Chrome. Same HTML as Chromium. The
+script tries `weasyprint`, then `python3 -c "import weasyprint"`.
+
+Needs Pango/Cairo (typical on Debian: `libpango-1.0-0`, `libcairo2`).
+Install the Python package in a venv, or with
+`pip install --user --break-system-packages weasyprint` if the OS
+blocks system-site pip (PEP 668). Do not use sudo.
+
+WeasyPrint reads `@font-face` from disk. Run it with the HTML file's
+directory as cwd (the build script does this).
 
 ## Chat after success
 

--- a/scientific-fa-translation/references/rtl-bidi.md
+++ b/scientific-fa-translation/references/rtl-bidi.md
@@ -11,8 +11,8 @@ PDF (`references/pdf-output.md`) with maximum bidi precision.
 
 When the print engine is XeLaTeX, isolate with `\lr{…}` / `\en{…}` and
 put listings in a `latin` environment (see `assets/rtl-document.tex`).
-The HTML rules below apply to an explicit HTML ask or the Chromium
-print fallback (`assets/rtl-document.html`).
+The HTML rules below apply to an explicit HTML ask or the Chromium /
+WeasyPrint print fallback (`assets/rtl-document.html`).
 
 ## Document root
 
@@ -97,6 +97,38 @@ parentheses, punctuation, or digits.
 A whole English bibliography, code listing, or equation block gets
 `dir="ltr"` on the HTML container, or a `latin` environment in TeX,
 not a token-by-token wrap.
+
+## Joined LTR runs (one isolate)
+
+If two English tokens are linked by `/`, `-`, `->`, or parentheses, wrap
+the **whole** cluster. A slash or parenthesis sitting in RTL between two
+`<span dir="ltr">` islands reverses the visible order.
+
+```html
+<!-- Wrong: renders as OP_NOTIF/OP_IF and :)2026-08-09( 1.0.1 -->
+<span dir="ltr">OP_IF</span>/<span dir="ltr">OP_NOTIF</span>
+<strong><span dir="ltr">1.0.1</span></strong> (<span dir="ltr">2026-08-09</span>)
+
+<!-- Right -->
+<span dir="ltr">OP_IF/OP_NOTIF</span>
+<span dir="ltr">1.0.1 (2026-08-09)</span>
+<span dir="ltr">STARTED -&gt; LOCKED_IN</span>
+<span dir="ltr">1109/2016 (55%)</span>
+<span dir="ltr">256/257</span>
+```
+
+```tex
+\en{OP_IF/OP_NOTIF}
+\en{1.0.1 (2026-08-09)}
+\en{STARTED -> LOCKED_IN}
+```
+
+Same rule for `Taproot/P2TR`, `300-400`, `2017–2024`, and
+`Adam (Kingma \& Ba, 2015)`. Persian separators between Persian words
+(`سیاست/پالایه`, `و/یا`) stay outside LTR spans.
+
+Do not treat `pdftotext` as visual truth on an RTL PDF. Rasterize a page
+(`pdftoppm -png -f 1 -l 1 file.pdf /tmp/p`) and look at the PNG.
 
 ## Wrong vs right
 
@@ -197,11 +229,14 @@ Never reverse English letter order by hand. Never rewrite `(Adam)` as
 
 ## Self-check
 
-1. Open the HTML file, not the chat transcript.
+1. Open the HTML file or a rasterized PDF page, not the chat transcript
+   and not `pdftotext` alone.
 2. Scan every English island: parentheses enclose the English, not the
    Persian.
 3. Sentence-final periods sit at the right edge of the Persian sentence.
-4. Code blocks are LTR, left-aligned, and optically identical to the
+4. Slash- or date-joined English still reads left-to-right
+   (`OP_IF/OP_NOTIF`, `1.0.1 (2026-08-09)`).
+5. Code blocks are LTR, left-aligned, and optically identical to the
    source listing. Images are the source files, unmirrored, in source
    order.
-5. No `ك` / `ي` introduced while editing markup.
+6. No `ك` / `ي` introduced while editing markup.

--- a/scientific-fa-translation/scripts/build-pdf.sh
+++ b/scientific-fa-translation/scripts/build-pdf.sh
@@ -1,40 +1,103 @@
 #!/usr/bin/env bash
-# Compile a XeLaTeX document and copy the PDF to ~/Documents/books.
+# Compile a Persian print document and copy the PDF to ~/Documents/books.
+# Engine order: XeLaTeX (for .tex), then Chromium, then WeasyPrint (for .html).
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "usage: build-pdf.sh <file.tex> [slug]" >&2
+  echo "usage: build-pdf.sh <file.tex|file.html> [slug]" >&2
   exit 2
 fi
 
-tex=$1
-if [[ ! -f "$tex" ]]; then
-  echo "build-pdf.sh: not a file: $tex" >&2
+src=$1
+if [[ ! -f "$src" ]]; then
+  echo "build-pdf.sh: not a file: $src" >&2
   exit 1
 fi
 
-tex_dir=$(cd "$(dirname "$tex")" && pwd)
-tex_base=$(basename "$tex")
-stem=${2:-${tex_base%.tex}}
+src_dir=$(cd "$(dirname "$src")" && pwd)
+src_base=$(basename "$src")
+ext=${src_base##*.}
+stem_src=${src_base%.*}
+stem=${2:-$stem_src}
 dest_dir="${HOME}/Documents/books"
 dest="${dest_dir}/${stem}.pdf"
 
-if ! command -v xelatex >/dev/null 2>&1; then
-  echo "build-pdf.sh: xelatex not found" >&2
-  exit 1
-fi
-
 mkdir -p "$dest_dir"
-cd "$tex_dir"
+cd "$src_dir"
 
-xelatex -interaction=nonstopmode -halt-on-error "$tex_base"
-xelatex -interaction=nonstopmode -halt-on-error "$tex_base"
+find_chrome() {
+  local c
+  for c in chromium chromium-browser google-chrome google-chrome-stable; do
+    if command -v "$c" >/dev/null 2>&1; then
+      printf '%s\n' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
 
-pdf="${tex_base%.tex}.pdf"
-if [[ ! -f "$pdf" ]]; then
-  echo "build-pdf.sh: expected PDF missing: ${tex_dir}/${pdf}" >&2
-  exit 1
-fi
+html_to_pdf() {
+  local html=$1
+  local out=$2
+  local chrome
+  if chrome=$(find_chrome); then
+    "$chrome" --headless --disable-gpu --no-pdf-header-footer \
+      --print-to-pdf="$out" "file://$(realpath "$html")"
+    return 0
+  fi
+  if command -v weasyprint >/dev/null 2>&1; then
+    weasyprint "$html" "$out"
+    return 0
+  fi
+  if python3 -c "import weasyprint" >/dev/null 2>&1; then
+    python3 -c 'from weasyprint import HTML; import sys; HTML(sys.argv[1]).write_pdf(sys.argv[2])' \
+      "$html" "$out"
+    return 0
+  fi
+  echo "build-pdf.sh: need Chromium or WeasyPrint for HTML (xelatex missing or .html input)" >&2
+  echo "build-pdf.sh: install weasyprint in a venv, or: pip install --user --break-system-packages weasyprint" >&2
+  return 1
+}
 
-cp -f "$pdf" "$dest"
-echo "$dest"
+compile_tex() {
+  if ! command -v xelatex >/dev/null 2>&1; then
+    return 1
+  fi
+  xelatex -interaction=nonstopmode -halt-on-error "$src_base"
+  xelatex -interaction=nonstopmode -halt-on-error "$src_base"
+  local pdf="${src_base%.tex}.pdf"
+  if [[ ! -f "$pdf" ]]; then
+    echo "build-pdf.sh: expected PDF missing: ${src_dir}/${pdf}" >&2
+    return 1
+  fi
+  cp -f "$pdf" "$dest"
+  return 0
+}
+
+case "$ext" in
+  tex)
+    if compile_tex; then
+      echo "$dest"
+      exit 0
+    fi
+    html_fallback="${stem_src}.html"
+    if [[ -f "$html_fallback" ]]; then
+      echo "build-pdf.sh: xelatex not usable; falling back to $html_fallback" >&2
+      html_to_pdf "$html_fallback" "$dest"
+      echo "$dest"
+      exit 0
+    fi
+    echo "build-pdf.sh: xelatex not found and no ${html_fallback} next to the .tex" >&2
+    echo "build-pdf.sh: write the HTML from assets/rtl-document.html and retry:" >&2
+    echo "  $0 ${src_dir}/${html_fallback} ${stem}" >&2
+    exit 1
+    ;;
+  html|htm)
+    html_to_pdf "$src_base" "$dest"
+    echo "$dest"
+    ;;
+  *)
+    echo "build-pdf.sh: expected .tex or .html, got: $src_base" >&2
+    exit 2
+    ;;
+esac

--- a/scientific-fa-translation/scripts/fetch-vazirmatn.sh
+++ b/scientific-fa-translation/scripts/fetch-vazirmatn.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Download Vazirmatn Regular + Bold (Western digits) into a fonts/ directory.
+# Do not fetch the UI-FD / Farsi-digits cut.
+set -euo pipefail
+
+dest=${1:-fonts}
+ver=33.003
+url="https://github.com/rastikerdar/vazirmatn/releases/download/v${ver}/vazirmatn-v${ver}.zip"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$dest"
+curl -fsSL -o "$tmp/vazirmatn.zip" "$url"
+unzip -q -o "$tmp/vazirmatn.zip" \
+  "fonts/ttf/Vazirmatn-Regular.ttf" \
+  "fonts/ttf/Vazirmatn-Bold.ttf" \
+  -d "$tmp"
+cp -f "$tmp/fonts/ttf/Vazirmatn-Regular.ttf" "$tmp/fonts/ttf/Vazirmatn-Bold.ttf" "$dest/"
+echo "$dest/Vazirmatn-Regular.ttf"
+echo "$dest/Vazirmatn-Bold.ttf"


### PR DESCRIPTION
XeLaTeX-only build-pdf.sh left the agent stuck without TeX or Chrome. Embed Vazirmatn Regular (not UI-FD) and isolate slash/date English as one run.