### PR TITLE
fix: keep technical collocations as atomic English

### DIFF
--- a/.cursor/skills/scientific-fa-translation/SKILL.md
+++ b/.cursor/skills/scientific-fa-translation/SKILL.md
@@ -35,7 +35,7 @@ Override only when the user says so.
 | --- | --- |
 | Direction | English → فارسی علمی |
 | Register | Formal فارسی معیار. No colloquial forms. |
-| Technical terms | Named artifacts stay English. General scholarly language is Persian. See below. |
+| Technical terms | Named artifacts stay English. Multi-word technical collocations stay English as one unit. General scholarly language is Persian. |
 | First mention | Named English terms: English only, no gloss, unless `references/glossary.md` says so. |
 | Output | Printable PDF at `~/Documents/books/<slug>.pdf`. Chat is a short pointer, not RTL. |
 | PDF RTL | Maximum precision via XeLaTeX + `xepersian`. See `references/pdf-output.md`. |
@@ -61,8 +61,9 @@ conversation and do not paste the article into chat.
    footnotes, citations. Copy every source image into the working
    tree (`figures/` next to the `.tex`) and keep the same sequence
    relative to the surrounding text.
-4. Scan domain terms. Check `references/glossary.md`. New *names*
-   stay English; new general words get a Persian row. Append both.
+4. Scan domain terms. Check `references/glossary.md`. New *names* and
+   new multi-word technical collocations stay English (whole NP);
+   new general words get a Persian row. Append both.
 5. Translate section by section. Do not add, omit, or soften claims.
    Preserve hedge language (`may`, `might`, `suggest`, `remain unknown`).
 6. RTL pass on the print source (`.tex` with `\lr` / `latin`, or HTML
@@ -89,6 +90,18 @@ Persianize. Do not invent فرهنگستان equivalents.
 - Formulas, code, units, and statistics (`p`, `n`, `SD`, …)
 - People’s names, journal names, and DOIs
   (also conference names, URLs, and bibliography titles)
+- **Multi-word technical collocations (atomic).** A 2–5 word domain
+  label in the source is one English unit. Do not calque it. Do not
+  half-translate it. If unsure whether it is a term of art or ordinary
+  prose, keep the **whole NP** in English and add it to the glossary.
+
+  Isolate the entire phrase in one `\lr{…}` / `\en{…}`. Do not attach
+  Persian morphology (`APIها`, `Goی`).
+
+  Forbidden: `apiهای ترکیب‌پذیر`, `خوشه Kubernetes`, `بسته‌های Go`,
+  `استقرار و پیکربندی` when the source is `deployment and configuration`.
+  Required: `composable APIs`, `Kubernetes cluster`,
+  `reusable Go packages`, `deployment and configuration`.
 
 **Write in Persian.** Translate these out of English. Never leave the
 English word in the Persian sentence.
@@ -98,13 +111,17 @@ English word in the Persian sentence.
   vocabulary: مقاله، روش‌ها، بحث، …)
 - Section titles: مقدمه، بحث، and the rest of the heading table in
   `references/scientific-style.md`
-- Conceptual explanation for the reader: the surrounding prose that
-  *says what a term means* is Persian. The named term inside it stays
-  English.
+- Conceptual explanation for the reader: the surrounding *clause* that
+  *says what a term means* is Persian. The term itself — including a
+  multi-word collocation — stays English. A glossary Translate row for
+  a single word does **not** split a collocation that contains it.
 
 Example: «در این روش از \en{gradient descent} برای کمینه کردن تابع
 هزینه استفاده می‌شود.» — روش / کمینه کردن / استفاده می‌شود are
 Persian; `gradient descent` stays English.
+
+Example: «\en{GitOps Toolkit} مجموعه‌ای از \en{composable APIs} و
+\en{reusable Go packages} است.» — not «APIهای ترکیب‌پذیر».
 
 ## Persian mechanics
 
@@ -125,8 +142,9 @@ Chat does not need to be RTL.
 On the **PDF** (non-negotiable when producing a printable file):
 
 - Prefer XeLaTeX + `xepersian` from `assets/rtl-document.tex`.
-- Isolate every English term, number cluster, formula, URL, and inline
-  code with `\lr{…}` (or `<span dir="ltr">` on the HTML fallback).
+- Isolate every English term, **whole technical collocation**, number
+  cluster, formula, URL, and inline code with `\lr{…}` (or
+  `<span dir="ltr">` on the HTML fallback).
   Slash-, arrow-, or parenthesis-joined English (`OP_IF/OP_NOTIF`,
   `STARTED -> LOCKED_IN`, `1.0.1 (2026-08-09)`) is **one** isolate, not
   two spans with punctuation between them.
@@ -169,6 +187,7 @@ the Chromium / WeasyPrint fallback in `references/pdf-output.md`.
 - [ ] No added, omitted, or softened scientific claims
 - [ ] Hedge language preserved
 - [ ] Names/acronyms/formulas/units/stats/people/journals/DOIs stay English
+- [ ] Multi-word technical collocations are one English isolate; no calque or half-translation
 - [ ] Verbs, general words, section titles, and explanations are Persian
 - [ ] Citations, equations, numbers, and units unchanged
 - [ ] `ک`/`ی` Persian; نیم‌فاصله present; no colloquial forms

--- a/.cursor/skills/scientific-fa-translation/references/glossary.md
+++ b/.cursor/skills/scientific-fa-translation/references/glossary.md
@@ -1,25 +1,33 @@
 # Glossary
 
-Living list for this skill. Classify every token against the two
-columns below, then add a row if it is new.
+Living list for this skill. Classify against Keep English vs Translate,
+then add a row if it is new. Multi-word technical collocations are
+atomic: store and emit the **whole phrase**, not the pieces.
 
 ## Rules
 
 1. **Keep English:** algorithm / library / protocol / product names;
    acronyms (`API`, `PCR`, `GPU`, `CI`, …); formulas, code, units,
-   statistics (`p`, `n`, `SD`, …); people’s names, journals, DOIs.
-   Output the exact English form in an LTR isolate. Never substitute a
-   Persian neologism.
+   statistics (`p`, `n`, `SD`, …); people’s names, journals, DOIs;
+   **multi-word technical collocations as whole phrases**.
+   Output the exact English form in one LTR isolate. Never substitute a
+   Persian neologism. Never calque or half-translate a collocation.
 2. **Write in Persian:** verbs and sentence structure; general words
-   (روش، نتایج، بررسی); section titles (مقدمه، بحث، …); conceptual
-   explanation for the reader. Never leave those in English.
-3. If a *name* is missing from **Keep English**, keep English and add
-   a row. If a *general word* is missing from **Translate**, write
-   Persian and add a row.
-4. Do not add فرهنگستان coinages for named artifacts unless the user
+   (روش، نتایج، بررسی) when they are not inside a keep-English
+   collocation; section titles (مقدمه، بحث، …); conceptual explanation
+   for the reader. Never leave those in English.
+3. If a *name* or a *collocation* is missing from **Keep English**, keep
+   the whole English NP and add a row. If a *general word* is missing
+   from **Translate** and it is not part of a collocation, write Persian
+   and add a row.
+4. A Translate row for one word does not split a longer English NP that
+   contains it.
+5. Do not add فرهنگستان coinages for named artifacts unless the user
    puts them in this file.
-5. Matching is case-sensitive only when the source is (e.g. `BERT` vs
+6. Matching is case-sensitive only when the source is (e.g. `BERT` vs
    a generic `bert` identifier in code — follow the source).
+7. No Persian morphology on English tokens (`APIها`, `Goی`). Plural is
+   English inside the isolate (`APIs`).
 
 ## Translate (Persian)
 
@@ -77,11 +85,26 @@ English.
 | steganography | پنهان‌نگاری |
 
 `dataset` as a named corpus (`ImageNet`, `GLUE`) is a product/name and
-stays English.
+stays English. A Translate row (`deployment` → استقرار) does not split
+`deployment and configuration`; that collocation stays English.
 
 ## Keep English
 
 Non-exhaustive. Anything of this kind stays English even if unlisted.
+
+### Atomic collocations
+
+Keep the **entire source phrase** in one isolate. Do not calque or
+half-translate. Add new document NPs here as whole rows.
+
+| Term | Notes |
+| --- | --- |
+| composable APIs | not «APIهای ترکیب‌پذیر» |
+| reusable Go packages | not «بسته‌های Go» |
+| Kubernetes cluster | not «خوشه Kubernetes» |
+| deployment and configuration | not «استقرار و پیکربندی» when used as a domain label |
+| Continuous Delivery workflows | not «جریان‌های کاری پیوسته» |
+| version-controlled approach to operations | not a word-for-word calque |
 
 ### Algorithms, libraries, protocols, products
 

--- a/.cursor/skills/scientific-fa-translation/references/rtl-bidi.md
+++ b/.cursor/skills/scientific-fa-translation/references/rtl-bidi.md
@@ -72,8 +72,14 @@ Also:
 
 ## Isolate every LTR run
 
-Wrap each English term, acronym, number cluster, citation key, formula,
-URL, file path, and inline code:
+Wrap each English term, **whole technical collocation**, acronym, number
+cluster, citation key, formula, URL, file path, and inline code. A
+collocation is one isolate, not one span per word:
+
+```html
+<span dir="ltr">composable APIs</span>
+<span dir="ltr">Kubernetes cluster</span>
+```
 
 ```html
 <span dir="ltr">gradient descent</span>

--- a/.cursor/skills/scientific-fa-translation/references/scientific-style.md
+++ b/.cursor/skills/scientific-fa-translation/references/scientific-style.md
@@ -7,8 +7,10 @@ faithfulness to the source science first, then readable فارسی معیار.
 
 - Formal written Persian. No spoken reductions: not `میشه`, `می‌خواد`,
   `چونکه` as a default, `اصلاً` as filler.
-- Prefer clear scientific prose over calques. Do not copy English
-  word order when it produces unreadable Persian.
+- Prefer clear scientific prose over sentence-level calques. Do not
+  copy English *clause* word order when it produces unreadable Persian.
+  Do not “fix” a technical NP by translating it word-by-word either:
+  that is a collocation calque and is forbidden (see Terminology).
 - Keep the author's epistemic stance. `may` / `might` / `suggest` /
   `appear to` / `remain unknown` must not become certainty.
 - Do not add background, examples, or conclusions the source lacks.
@@ -32,7 +34,8 @@ faithfulness to the source science first, then readable فارسی معیار.
 
 ## Terminology
 
-Policy lives in `glossary.md`. Two columns only:
+Policy lives in `glossary.md`. Named artifacts and **atomic multi-word
+collocations** stay English. Ordinary scholarly language is Persian.
 
 **Keep English** (LTR-isolated). Do not coin فرهنگستان equivalents.
 
@@ -40,20 +43,29 @@ Policy lives in `glossary.md`. Two columns only:
 - Acronyms (`API`, `PCR`, `GPU`, `CI`, and the same class)
 - Formulas, code, units, statistics (`p`, `n`, `SD`, …)
 - People’s names, journal names, DOIs (and bibliography entries)
+- Multi-word technical collocations: a 2–5 word domain label in the
+  source is one English unit. Do not calque. Do not half-translate
+  (`خوشه Kubernetes`, `APIهای ترکیب‌پذیر`). No Persian affixes on
+  English tokens. If unsure, keep the whole NP in English.
 
 **Write in Persian.** Do not leave these in English.
 
 - Verbs and sentence structure
-- General words: روش، نتایج، بررسی
+- General words: روش، نتایج، بررسی — only when they are *not* inside
+  a keep-English collocation
 - Section titles: مقدمه، بحث، …
-- Conceptual explanation for the reader (the prose around a term)
+- Conceptual explanation for the reader (the clause around a term)
 
 One English form per named concept for the whole document. On first
 use, do not add a gloss like `نزول گرادیان (gradient descent)` unless
 the glossary says to.
 
-When unsure, classify against those two columns. Do not default a
-general word to English. Ask only if the class is still unclear.
+A Translate row for a single word (`deployment` → استقرار) does not
+authorize splitting `deployment and configuration`. Collocation wins.
+
+When unsure whether a short NP is a term of art, keep it English and
+add the whole phrase to Keep English. Do not default a collocation to
+Persian word-by-word.
 
 ## What not to translate
 
@@ -61,6 +73,7 @@ Leave unchanged (aside from LTR markup):
 
 - Names of algorithms, libraries, protocols, and products
 - Acronyms (`API`, `PCR`, `GPU`, `CI`, …)
+- Multi-word technical collocations (whole NP, one isolate)
 - Formulas, code, units, statistical symbols (`p`, `n`, `SD`, …)
 - People’s names; journal, conference, and DOI/URL strings
 - Bibliography entries: authors, article titles, journals, years

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ via `@font-face` when the font is not installed on the system.
 
 - Algorithm, library, protocol, and product names
 - Acronyms such as `API`, `PCR`, `GPU`, `CI`
+- Multi-word technical collocations as one English unit (no calque,
+  no half-translation: `Kubernetes cluster`, not «خوشه Kubernetes»)
 - Formulas, code, units, and statistics (`p`, `n`, `SD`)
 - People’s names, journal names, and DOIs
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Locks rule 2: a 2–5 word technical collocation in the source is one English unit.

- No calque (`جریان‌های کاری پیوسته` for Continuous Delivery workflows)
- No half-translation (`خوشه Kubernetes`, `APIهای ترکیب‌پذیر`)
- No Persian morphology on English tokens
- If unsure, keep the whole NP in English
- A single-word Translate glossary row (e.g. deployment → استقرار) must not split a longer collocation

Surrounding verbs and explanation stay Persian.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e931297-66bc-4fbe-b46d-f01692b37408?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e931297-66bc-4fbe-b46d-f01692b37408&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

