### PR TITLE
docs: add Cursor Cloud environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,38 @@ Do not use that skill for coding, commits, UI copy, or casual chat.
   `--level journal` when the fixture is a paper, not a sysadmin guide.
 - Keep `SKILL.md` short. It is loaded in full whenever the skill
   triggers; detail belongs in `references/`.
+
+## Cursor Cloud specific instructions
+
+This repo is tooling for a Cursor skill, not a running service. The dev
+loop is lint → test → build a PDF; there is nothing to keep running.
+
+- Lint / test / build commands live in `README.md` and
+  `.github/workflows/ci.yml`; use those rather than reinventing them.
+  Lint is `shellcheck -S warning $(git ls-files '*.sh')` plus
+  `python3 -m py_compile $(git ls-files '*.py')`; tests are
+  `bash tests/run.sh`; the deliverable is built with
+  `scripts/build-pdf.sh <file.tex|file.html> <slug> --verify` after
+  `scripts/check-fa.py <file> --strict`. Run `scripts/preflight.sh` to
+  see which engines/fonts/tools the machine has.
+- No repository-level package deps: everything is Python 3 stdlib or
+  system packages baked into the environment (`shellcheck`,
+  `python3-pil`/Pillow, `poppler-utils`, `fonts-vazirmatn`,
+  `texlive-xetex` + `texlive-lang-arabic` for xepersian, `latexmk`,
+  `google-chrome`). The boot-time update script is intentionally a no-op.
+- Preferred `.tex`/XeLaTeX path is currently blocked by a toolchain
+  mismatch, not a missing dependency: the shipped `assets/rtl-document.tex`
+  sets a Latin `\setdigitfont` (Western digits, by design), which TeX
+  Live 2023's xepersian 25.0 rejects with
+  `xepersian-mathdigitspec Error: The font "TeX Gyre Termes" does not
+  contain U+06F0`. Build via the documented HTML path instead
+  (`scripts/build-pdf.sh doc.html <slug> --verify`, Chromium engine) to
+  produce a print-ready RTL PDF. Only touch the template's digit-font
+  handling if the `.tex` path itself is the task.
+- Headless `google-chrome` prints harmless `dbus`/`UPower` errors to
+  stderr in this VM; the PDF is still written — look for the
+  "bytes written to file …" line, not the noise.
+- `scripts/fetch-vazirmatn.sh fonts/` reuses the installed Vazirmatn
+  system face offline (no network needed) to drop the TTFs beside an
+  HTML build. `--verify` rasterises sample pages to PNG; judge RTL from
+  those images, never from `pdftotext`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cloud Agent development environment for this skill repo, and records durable, non-obvious setup notes for future agents under `## Cursor Cloud specific instructions` in `AGENTS.md`. No source/tooling code was changed.

This repo is tooling for a Cursor skill (Python + bash) that translates English → scientific Persian and produces print-ready RTL PDFs. The dev loop is lint → test → build a PDF; there are no long-running services.

## Environment set up (system deps, captured in the snapshot)

- `shellcheck` — shell lint
- `python3-pil` (Pillow) — enables the `prepare-figures` branch of the test suite
- `poppler-utils` — `pdfinfo`/`pdffonts`/`pdftoppm` for `build-pdf.sh --verify`
- `fonts-vazirmatn` — preferred Persian text face
- `texlive-xetex`, `texlive-lang-arabic` (xepersian), `texlive-latex-recommended`, `texlive-latex-extra`, `texlive-fonts-recommended`, `latexmk` — XeLaTeX path
- `google-chrome` was already present — HTML → PDF engine

The boot-time update script is intentionally a no-op: there are no repository-level package dependencies (everything is Python stdlib or the system packages above).

## Verified

| Step | Command | Result |
| --- | --- | --- |
| Lint (shell) | `shellcheck -S warning $(git ls-files '*.sh')` | pass |
| Lint (python) | `python3 -m py_compile $(git ls-files '*.py')` | pass |
| Tests | `bash tests/run.sh` | all pass (incl. Pillow figure branch) |
| Preflight | `scripts/preflight.sh` | XeLaTeX+xepersian, Chrome, Vazirmatn, poppler all green |
| Checker | `scripts/check-fa.py hello.html --strict` | clean (and correctly flagged a real `command` calque during authoring) |
| Build (deliverable) | `scripts/build-pdf.sh hello.html <slug> --verify` | 2-page RTL PDF, embedded Vazirmatn + DejaVu Sans Mono |

Hello-world: translated a short Kubernetes-scheduling snippet into scientific Persian following the skill's isolation rules, linted it, and built a print-ready RTL PDF via the documented HTML/Chromium path.

[Rendered hello-world RTL Persian PDF, page 1](https://cursor.com/agents/bc-c51b6f87-3dfe-4710-8c40-f8cd05147be8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_pdf_page1.png)

## Known caveat recorded in AGENTS.md

The preferred `.tex`/XeLaTeX path is blocked by a toolchain mismatch (not a missing dependency): the shipped `assets/rtl-document.tex` sets a Latin `\setdigitfont` (Western digits, by design), which TeX Live 2023's xepersian `25.0` rejects with `xepersian-mathdigitspec Error: The font "TeX Gyre Termes" does not contain U+06F0`. The unmodified template reproduces this, so the template was left untouched; the documented HTML/Chromium path is used to produce the deliverable.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c51b6f87-3dfe-4710-8c40-f8cd05147be8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c51b6f87-3dfe-4710-8c40-f8cd05147be8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

