### PR TITLE
feat: add observability, containers, ci, iac, and linux domain packs

### DIFF
--- a/references/glossary-domains.md
+++ b/references/glossary-domains.md
@@ -93,6 +93,90 @@ Flux, Argo, and continuous-delivery documentation.
 | version-controlled approach to operations | keep whole; do not calque |
 | reconciliation, drift, source controller | field nouns |
 
+## observability
+
+Prometheus, Grafana, OpenTelemetry, and monitoring runbooks. Not a
+generic DevOps pack: `metric` is a field noun here and ordinary prose
+in a statistics paper.
+
+| Term | Also covers |
+| --- | --- |
+| metric, trace, span | never سنجه / ردیابی / دهانه in this lexicon |
+| exporter | Prometheus / OpenTelemetry exporter |
+| scrape target | `scrape`, `scrape interval` |
+| service level objective | `SLO`; never هدف سطح خدمت |
+| service level indicator | `SLI`; never شاخص سطح خدمت |
+| cardinality | label cardinality in a time-series store; never کثرت برچسب |
+| dashboard | Grafana / Prometheus dashboard; never تابلوی کنترل |
+
+`metric` is this pack's most error-prone row: it reads like ordinary
+prose and drifts to سنجه. Enforced by the `observability` scope in
+`term-pairs.tsv`. Lint with `--domains observability`.
+
+## containers
+
+Docker, containerd, and OCI runtime documentation. Kubernetes cluster
+vocabulary stays in the `kubernetes` pack; Helm chart/release/values
+belong there too.
+
+| Term | Also covers |
+| --- | --- |
+| container | never ظرف in this lexicon |
+| container image | never تصویر ظرف or تصویر کانتینر; not a bare «تصویر» |
+| image registry | `registry`; never انباره تصویر |
+| overlay filesystem | `overlayfs` |
+| container runtime | `runtime`; never زمان اجرای ظرف |
+
+`container` is this pack's most error-prone row. Enforced by the
+`containers` scope in `term-pairs.tsv`. Lint with `--domains containers`.
+
+## ci
+
+GitHub Actions, GitLab CI, Jenkins — build and test, not delivery.
+The `gitops` pack covers Flux/Argo CD.
+
+| Term | Also covers |
+| --- | --- |
+| pipeline | never خط لوله in this lexicon |
+| runner | `GitHub-hosted runner`, `self-hosted runner` |
+| artifact | `build artifact`; never مصنوع |
+| workflow | GitHub Actions / GitLab CI workflow, not a GitOps reconciliation loop |
+
+`pipeline` is this pack's most error-prone row. Enforced by the `ci`
+scope in `term-pairs.tsv`. Lint with `--domains ci`. Do not pass
+`--domains gitops` instead of this pack.
+
+## iac
+
+Terraform, OpenTofu, Pulumi, and Ansible. `state` as ordinary
+«وضعیت» is not a row — only the labeled IaC phrases.
+
+| Term | Also covers |
+| --- | --- |
+| playbook | Ansible playbook; never کتابچه اجرا |
+| inventory | Ansible inventory; never سیاهه موجودی |
+| module | Terraform / Pulumi module; never پیمانه |
+| provider | Terraform provider; never ارائه‌دهنده |
+| state file | Terraform state file; never فایل وضعیت |
+| remote state | Terraform remote state; never وضعیت راه‌دور |
+
+`playbook` and `state file` are the error-prone rows. Enforced by the
+`iac` scope in `term-pairs.tsv`. Lint with `--domains iac`.
+
+## linux
+
+systemd, journald, and cgroup documentation. `unit` and `journal` as
+ordinary Persian واحد / ژورنال are not rows — only the labeled phrases.
+
+| Term | Also covers |
+| --- | --- |
+| cgroup | never گروه کنترل in this lexicon |
+| systemd unit | never واحد سیستم‌دی |
+| systemd journal | `journald`; never ژورنال سیستم‌دی |
+
+`cgroup` is this pack's most error-prone row. Enforced by the `linux`
+scope in `term-pairs.tsv`. Lint with `--domains linux`.
+
 ## ml
 
 Machine-learning papers. Usually read at `journal` level, where one-word

--- a/references/term-pairs.tsv
+++ b/references/term-pairs.tsv
@@ -63,3 +63,35 @@ miner	استخراج‌کننده	bitcoin	system-docs
 consensus	اجماع	bitcoin	system-docs
 activation	فعال‌سازی	bitcoin	system-docs
 dataset	مجموعه داده	ml	system-docs
+metric	سنجه	observability	system-docs
+metric	سنجه‌ها	observability	system-docs
+trace	ردیابی	observability	system-docs
+span	دهانه	observability	system-docs
+exporter	صادرکننده	observability	system-docs
+scrape target	هدف جمع‌آوری	observability	all
+service level objective	هدف سطح خدمت	observability	all
+service level indicator	شاخص سطح خدمت	observability	all
+cardinality	کثرت برچسب	observability	all
+dashboard	تابلوی کنترل	observability	all
+container	ظرف	containers	system-docs
+container	ظرف‌ها	containers	system-docs
+container image	تصویر ظرف	containers	all
+container image	تصویر کانتینر	containers	all
+image registry	انباره تصویر	containers	all
+overlay filesystem	سیستم‌فایل پوششی	containers	all
+container runtime	زمان اجرای ظرف	containers	all
+pipeline	خط لوله	ci	system-docs
+pipeline	خط لوله‌ها	ci	system-docs
+runner	اجراکننده	ci	system-docs
+artifact	مصنوع	ci	system-docs
+artifact	مصنوع‌ها	ci	system-docs
+workflow	جریان کاری	ci	system-docs
+playbook	کتابچه اجرا	iac	system-docs
+inventory	سیاهه موجودی	iac	all
+module	پیمانه	iac	system-docs
+provider	ارائه‌دهنده	iac	system-docs
+state file	فایل وضعیت	iac	all
+remote state	وضعیت راه‌دور	iac	all
+cgroup	گروه کنترل	linux	system-docs
+systemd unit	واحد سیستم‌دی	linux	all
+systemd journal	ژورنال سیستم‌دی	linux	all

--- a/tests/fixtures/domains.tex
+++ b/tests/fixtures/domains.tex
@@ -1,0 +1,33 @@
+% !TEX program = xelatex
+% Fixture: DevOps domain-pack calques. Must lint clean without --domains,
+% and must report forbidden-fa with --domains all (and not leak across packs).
+\documentclass[a4paper,12pt]{article}
+\usepackage{fontspec}
+\usepackage{xepersian}
+\settextfont{Vazirmatn}
+\newcommand{\en}[1]{\lr{#1}}
+\pdfstringdefDisableCommands{\def\lr#1{#1}\def\en#1{#1}}
+
+\begin{document}
+
+\section*{مشاهده‌پذیری}
+سنجه و ردیابی هر دهانه را صادرکننده می‌نویسد.
+هدف جمع‌آوری و هدف سطح خدمت و شاخص سطح خدمت و کثرت برچسب
+در تابلوی کنترل دیده می‌شوند.
+
+\section*{ظرف‌ها}
+ظرف روی تصویر ظرف از انباره تصویر با سیستم‌فایل پوششی و
+زمان اجرای ظرف اجرا می‌شود. تصویر کانتینر مجاز نیست.
+
+\section*{ساخت و آزمون}
+خط لوله هر اجراکننده را به مصنوع می‌فرستد و جریان کاری را
+ثبت می‌کند.
+
+\section*{زیرساخت به‌عنوان کد}
+کتابچه اجرا و سیاهه موجودی و پیمانه و ارائه‌دهنده به
+فایل وضعیت و وضعیت راه‌دور وابسته‌اند.
+
+\section*{لینوکس}
+گروه کنترل و واحد سیستم‌دی و ژورنال سیستم‌دی را بررسی کنید.
+
+\end{document}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -105,8 +105,37 @@ else
   fail=1
 fi
 
-# prepare-figures.py: flatten alpha onto white so print engines cannot
-# composite it as a black rectangle.
+# Domain packs: calques are silent unless that pack (or --domains all) is on.
+expect_clean "$fixtures/domains.tex" --strict
+expect_checks "$fixtures/domains.tex" forbidden-fa
+
+obs_out=$(python3 "$lint" "$fixtures/domains.tex" --domains observability 2>&1) || true
+if grep -q سنجه <<<"$obs_out" && grep -q "خط لوله" <<<"$obs_out"; then
+  echo "FAIL observability pack leaked ci rows"
+  echo "$obs_out" | sed 's/^/    /'
+  fail=1
+elif grep -q سنجه <<<"$obs_out"; then
+  echo "ok   observability pack does not leak ci rows"
+else
+  echo "FAIL observability pack missed metric calque"
+  echo "$obs_out" | sed 's/^/    /'
+  fail=1
+fi
+
+ci_out=$(python3 "$lint" "$fixtures/domains.tex" --domains ci 2>&1) || true
+if grep -q "خط لوله" <<<"$ci_out" && grep -q سنجه <<<"$ci_out"; then
+  echo "FAIL ci pack leaked observability rows"
+  echo "$ci_out" | sed 's/^/    /'
+  fail=1
+elif grep -q "خط لوله" <<<"$ci_out"; then
+  echo "ok   ci pack does not leak observability rows"
+else
+  echo "FAIL ci pack missed pipeline calque"
+  echo "$ci_out" | sed 's/^/    /'
+  fail=1
+fi
+
+# prepare-figures.py: flatten alpha onto white so the print PDF matches the source.
 if python3 -c "import PIL.Image" 2>/dev/null; then
   alpha="$fixtures/figures/alpha.png"
   python3 - "$alpha" <<'PY'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds five DevOps domain packs, scoped separately so field-term calques do not leak across documents (no single `devops` pack).

| `--domains` | For | Example calques now enforced |
| --- | --- | --- |
| `observability` | Prometheus / Grafana / OpenTelemetry | سنجه، ردیابی، دهانه، هدف سطح خدمت |
| `containers` | Docker / containerd / OCI (not Kubernetes/Helm) | ظرف، تصویر ظرف، انباره تصویر |
| `ci` | GitHub Actions / GitLab CI / Jenkins (not GitOps CD) | خط لوله، اجراکننده، مصنوع |
| `iac` | Terraform / OpenTofu / Pulumi / Ansible | کتابچه اجرا، فایل وضعیت، پیمانه |
| `linux` | systemd / cgroup | گروه کنترل، واحد سیستم‌دی |

Bare ordinary words that would false-positive (`وضعیت`, `تصویر`, `واحد`) are not rows; only labeled phrases are.

## Tests

- `tests/fixtures/domains.tex` lints clean without `--domains`
- `--domains all` reports `forbidden-fa`
- `--domains observability` does not leak `ci` rows, and vice versa

`bash tests/run.sh` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c51b6f87-3dfe-4710-8c40-f8cd05147be8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c51b6f87-3dfe-4710-8c40-f8cd05147be8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

