### PR TITLE
fix: force UTF-8 output from check-fa.py

### DIFF
--- a/scripts/check-fa.py
+++ b/scripts/check-fa.py
@@ -32,6 +32,18 @@ import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 
+# Every finding this tool prints quotes Persian, and on Windows an
+# unredirected stdout defaults to the console ANSI code page (cp1252), which
+# cannot encode a single Persian letter. The first finding then dies with
+# UnicodeEncodeError and every check after it goes unreported - a lint that
+# exits non-zero for the wrong reason and hides the rest of its own output.
+# Force UTF-8 rather than depending on the locale.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):  # not a TextIOWrapper (test capture)
+        pass
+
 ZWNJ = "\u200c"
 FA_RANGE = "\u0600-\u06ff\ufb50-\ufdff\ufe70-\ufeff"
 FA_CHAR = re.compile(f"[{FA_RANGE}]")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -204,6 +204,22 @@ else
   fail=1
 fi
 
+# check-fa.py prints Persian, so it must not depend on the console encoding.
+# On Windows an unredirected stdout is cp1252 and the first finding dies with
+# UnicodeEncodeError, taking every later check down with it.
+cp1252_out=$(PYTHONIOENCODING=cp1252 python3 "$lint" "$fixtures/bad.tex"              --domains all 2>&1) || true
+if grep -q UnicodeEncodeError <<<"$cp1252_out"; then
+  echo "FAIL check-fa.py dies on a non-UTF-8 stdout (Windows console)"
+  echo "$cp1252_out" | sed 's/^/    /' | tail -5
+  fail=1
+elif grep -q full-page-figure <<<"$cp1252_out"; then
+  echo "ok   check-fa.py forces UTF-8 output"
+else
+  echo "FAIL check-fa.py under cp1252 did not report the last check"
+  echo "$cp1252_out" | sed 's/^/    /' | tail -5
+  fail=1
+fi
+
 if [[ $fail -eq 0 ]]; then
   echo "all tests passed"
 else


### PR DESCRIPTION
`check-fa.py` prints Persian in every finding, but it writes to whatever
encoding the console happens to offer. On Windows an unredirected stdout is
the ANSI code page (cp1252), which cannot encode a single Persian letter, so
the first finding kills the run:

```
  File "scripts/check-fa.py", line 664, in main
    print(f"     {path}:{f.line}: {f.message}")
UnicodeEncodeError: 'charmap' codec can't encode characters in position 126-129
```

The lint still exits non-zero, so it looks like it worked — but every check
after the first one goes unreported. `bash tests/run.sh` fails four of its
cases for this reason alone on a Windows checkout; on Linux with a non-UTF-8
`LC_ALL` the same thing happens.

## The change

Reconfigure `sys.stdout`/`sys.stderr` to UTF-8 at import, guarded so a
replaced stream (test capture) is left alone. Nothing else moves.

## Test

`tests/run.sh` gains one case that runs the `bad.tex` fixture under
`PYTHONIOENCODING=cp1252` and asserts both that no `UnicodeEncodeError`
appears and that the *last* expected check id is still reported — a check
that would pass if only the traceback were suppressed. It reproduces on
Linux CI, so it is not a Windows-only test.

Verified it fails without the fix and passes with it:

```
FAIL check-fa.py dies on a non-UTF-8 stdout (Windows console)   # fix reverted
ok   check-fa.py forces UTF-8 output                            # fix applied
```

`bash tests/run.sh`, `shellcheck -S warning`, and `python3 -m py_compile`
all pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)