### PR TITLE
feat: add PowerShell twins for the shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,51 @@ jobs:
       - name: Byte-compile python
         run: python3 -m py_compile $(git ls-files '*.py')
 
+      - name: PowerShell twins run on 5.1 and 7.x
+        run: |
+          set -e
+          fail=0
+
+          # Every shell script needs a same-named .ps1 twin, or the two
+          # platforms drift the moment one side is changed.
+          for sh in scripts/*.sh; do
+            ps1="${sh%.sh}.ps1"
+            if [ ! -f "$ps1" ]; then
+              echo "missing PowerShell twin for $sh"
+              fail=1
+            fi
+          done
+
+          for f in $(git ls-files '*.ps1'); do
+            # 5.1 decodes a BOM-less .ps1 with the system ANSI code page. A
+            # UTF-8 em dash then becomes U+201D, which the tokenizer treats
+            # as a double quote, and the whole file fails to parse. Staying
+            # ASCII removes the dependency on encoding entirely.
+            if LC_ALL=C grep -nP '[^\x00-\x7F]' "$f"; then
+              echo "$f: non-ASCII byte; PowerShell 5.1 will mis-decode it"
+              fail=1
+            fi
+            # PowerShell-7-only syntax breaks 5.1 outright.
+            if grep -nE '\?\?|ForEach-Object[[:space:]]+-Parallel|Join-String|\$IsCoreCLR' "$f"; then
+              echo "$f: PowerShell 7-only syntax; the twins must also run on 5.1"
+              fail=1
+            fi
+            if ! grep -q '^#Requires -Version 5\.1' "$f"; then
+              echo "$f: missing '#Requires -Version 5.1'"
+              fail=1
+            fi
+            # 7.4+ defaults $PSNativeCommandUseErrorActionPreference to true,
+            # so a non-zero exit code throws. Any file that probes a native
+            # command for its exit code must opt out.
+            if grep -q '\$LASTEXITCODE' "$f" &&
+               ! grep -q 'PSNativeCommandUseErrorActionPreference = \$false' "$f"; then
+              echo "$f: reads \$LASTEXITCODE without opting out of"
+              echo "  \$PSNativeCommandUseErrorActionPreference (throws on 7.4+)"
+              fail=1
+            fi
+          done
+          exit $fail
+
       - name: Checker regression tests
         run: bash tests/run.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
 __pycache__/
 *.pyc
+
+# TeX and browser build output. Running build-pdf against
+# assets/rtl-document.tex leaves these beside the template.
+*.aux
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.synctex.gz
+*.toc
+*.xdv
+assets/*.pdf
+verify-*.png
+
+# Fonts are fetched on demand by scripts/fetch-vazirmatn.*, never tracked.
+# Vazirmatn is SIL OFL 1.1: committing the TTFs would mean committing the
+# licence beside them, and the whole point of the fetch script is that the
+# repo does not carry binaries it can obtain.
+fonts/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ scripts/build-pdf.sh doc.tex my-slug --verify
 bash tests/run.sh
 ```
 
+On Windows, run the PowerShell twin of the same name instead — same
+behaviour, only the extension and the flag style change. They run on the
+Windows PowerShell 5.1 that ships with the OS as well as on PowerShell 7:
+
+```powershell
+.\scripts\preflight.ps1
+python scripts\check-fa.py doc.tex --level system-docs --strict
+.\scripts\build-pdf.ps1 doc.tex my-slug -Verify
+```
+
 Layout:
 
 ```text
@@ -86,6 +96,7 @@ references/source-ingest.md    fetching and extracting the source
 references/long-documents.md   sectioning, resume, ambiguity queue
 references/review.md           reviewing a finished translation
 scripts/preflight.sh           what this machine can build
+scripts/preflight.ps1          the Windows twin (likewise for the two below)
 scripts/check-fa.py            mechanical checker
 scripts/prepare-figures.py     flatten alpha; catch pdfimages negatives
 scripts/crop-source-figures.py crop artwork; never embed a full PDF page

--- a/assets/rtl-document.tex
+++ b/assets/rtl-document.tex
@@ -43,17 +43,38 @@
   \IfFontExistsTF{Shabnam}{\settextfont[Ligatures=TeX]{Shabnam}}{%
     \IfFontExistsTF{Sahel}{\settextfont[Ligatures=TeX]{Sahel}}{%
       \IfFontExistsTF{Amiri}{\settextfont[Ligatures=TeX]{Amiri}}{%
-        \settextfont[Ligatures=TeX]{DejaVu Sans}}}}}}
+        \IfFontExistsTF{Noto Naskh Arabic}{%
+          \settextfont[Ligatures=TeX]{Noto Naskh Arabic}}{%
+          \IfFontExistsTF{Tahoma}{\settextfont[Ligatures=TeX]{Tahoma}}{%
+            \settextfont[Ligatures=TeX]{DejaVu Sans}}}}}}}}
 % Latin text and digit face — Latin, so digits stay Western.
-\IfFontExistsTF{TeX Gyre Termes}{%
-  \setlatintextfont{TeX Gyre Termes}\setdigitfont{TeX Gyre Termes}}{%
-  \IfFontExistsTF{Liberation Serif}{%
-    \setlatintextfont{Liberation Serif}\setdigitfont{Liberation Serif}}{%
-    \setlatintextfont{DejaVu Serif}\setdigitfont{DejaVu Serif}}}
-% Monospace for listings.
-\IfFontExistsTF{TeX Gyre Cursor}{\setmonofont[Scale=0.92]{TeX Gyre Cursor}}{%
-  \IfFontExistsTF{DejaVu Sans Mono}{\setmonofont[Scale=0.90]{DejaVu Sans Mono}}{%
-    \setmonofont[Scale=0.90]{Liberation Mono}}}
+%
+% Every chain must cover Windows as well as Linux, and the LAST entry is
+% unguarded — if that face is missing too, fontspec aborts the build. A
+% chain made only of Linux faces therefore cannot compile on Windows at
+% all, which is what "DejaVu Serif" as the tail did.
+%
+% OS-native faces also come FIRST, and that ordering is not cosmetic. On
+% MiKTeX \IfFontExistsTF does not answer "no" for a face that is not
+% installed: it tries to *manufacture* a METAFONT font for it, the name is
+% truncated on the way ("TeX Gyre Term.cfg", "Liberation Ser.cfg"), makemf
+% fails, TeX carries on, and the run dies much later in the driver with
+% "dvipdfmx:fatal: Invalid font: -1 (4)". Testing a real system font first
+% never reaches that path. On Linux fontconfig answers honestly, so the
+% TeX Gyre / DejaVu tail still wins there.
+\IfFontExistsTF{Times New Roman}{%
+  \setlatintextfont{Times New Roman}\setdigitfont{Times New Roman}}{%
+  \IfFontExistsTF{TeX Gyre Termes}{%
+    \setlatintextfont{TeX Gyre Termes}\setdigitfont{TeX Gyre Termes}}{%
+    \IfFontExistsTF{Liberation Serif}{%
+      \setlatintextfont{Liberation Serif}\setdigitfont{Liberation Serif}}{%
+      \setlatintextfont{DejaVu Serif}\setdigitfont{DejaVu Serif}}}}
+% Monospace for listings. Same ordering rule.
+\IfFontExistsTF{Consolas}{\setmonofont[Scale=0.92]{Consolas}}{%
+  \IfFontExistsTF{Courier New}{\setmonofont[Scale=0.92]{Courier New}}{%
+    \IfFontExistsTF{TeX Gyre Cursor}{\setmonofont[Scale=0.92]{TeX Gyre Cursor}}{%
+      \IfFontExistsTF{Liberation Mono}{\setmonofont[Scale=0.90]{Liberation Mono}}{%
+        \setmonofont[Scale=0.90]{DejaVu Sans Mono}}}}}
 
 \newcommand{\en}[1]{\lr{#1}}
 

--- a/assets/rtl-document.tex
+++ b/assets/rtl-document.tex
@@ -23,11 +23,27 @@
 
 % Font resolution without hand-editing: first face that exists wins.
 % Persian text face.
+%
+% A local fonts/ directory beside this file wins over every system name,
+% and that is not a preference - it is the only way a *variable* font can
+% be used at all. Asked for a family name, XeTeX hands the driver a named
+% instance of the variable font, and xdvipdfmx cannot embed one: it warns
+% "Invalid TTC index (not TTC font)" and dies with
+% "dvipdfmx:fatal: Invalid font: -1 (4)". The identical file loaded by
+% *path* carries no instance index and embeds fine. Google Fonts ships
+% Vazirmatn as Vazirmatn-VariableFont_wght.ttf, which is what most Windows
+% machines have installed, so this is the common case and not an edge case.
+%
+% Put the files there with scripts/fetch-vazirmatn.sh run in the document's
+% own directory - the same fonts/ the HTML template embeds.
+\IfFontExistsTF{fonts/Vazirmatn-Regular.ttf}{%
+  \settextfont[Path=fonts/,BoldFont=Vazirmatn-Bold.ttf,
+               Ligatures=TeX]{Vazirmatn-Regular.ttf}}{%
 \IfFontExistsTF{Vazirmatn}{\settextfont[Ligatures=TeX]{Vazirmatn}}{%
   \IfFontExistsTF{Shabnam}{\settextfont[Ligatures=TeX]{Shabnam}}{%
     \IfFontExistsTF{Sahel}{\settextfont[Ligatures=TeX]{Sahel}}{%
       \IfFontExistsTF{Amiri}{\settextfont[Ligatures=TeX]{Amiri}}{%
-        \settextfont[Ligatures=TeX]{DejaVu Sans}}}}}
+        \settextfont[Ligatures=TeX]{DejaVu Sans}}}}}}
 % Latin text and digit face — Latin, so digits stay Western.
 \IfFontExistsTF{TeX Gyre Termes}{%
   \setlatintextfont{TeX Gyre Termes}\setdigitfont{TeX Gyre Termes}}{%

--- a/references/pdf-output.md
+++ b/references/pdf-output.md
@@ -55,7 +55,23 @@ the `.tex` and figures so the user can compile later.
 ## XeLaTeX + xepersian
 
 Start from `assets/rtl-document.tex`. Load `graphicx`, `hyperref`, and
-`geometry` **before** `xepersian`. The template resolves fonts itself with
+`geometry` **before** `xepersian`. Put the font beside the document first —
+the same `fonts/` the HTML template embeds, and the only form a *variable*
+font can be used in at all:
+
+```bash
+scripts/fetch-vazirmatn.sh fonts       # run in the document's directory
+```
+
+A family name is not enough when the only installed cut is a variable font:
+XeTeX hands the driver a named instance of it, `xdvipdfmx` refuses it with
+`Invalid TTC index (not TTC font)` and `dvipdfmx:fatal: Invalid font: -1 (4)`,
+and the build stops. The identical file loaded by **path** carries no
+instance index and embeds normally. Google Fonts ships Vazirmatn as
+`Vazirmatn-VariableFont_wght.ttf`, so this is the common case on Windows.
+`build-pdf.sh` prints the remedy when it recognises the driver error.
+
+The template resolves the rest itself with
 `\IfFontExistsTF`, so there is nothing to hand-edit — but confirm the chosen
 face covers Persian:
 

--- a/references/pdf-output.md
+++ b/references/pdf-output.md
@@ -27,10 +27,142 @@ Run this **first**, before choosing an approach:
 scripts/preflight.sh
 ```
 
+```powershell
+.\scripts\preflight.ps1
+```
+
 It reports which engines and fonts actually exist and prints the install
 command for what is missing. Do not plan a XeLaTeX build on a machine
 without XeLaTeX and then discover it at compile time — decide up front, and
 tell the user which engine will be used and what that costs.
+
+## Windows
+
+Every shell script has a PowerShell twin with the same name and the same
+behaviour, so the workflow is identical — only the extension and the flag
+style change:
+
+| POSIX | Windows |
+| --- | --- |
+| `scripts/preflight.sh` | `.\scripts\preflight.ps1` |
+| `scripts/build-pdf.sh doc.tex slug --verify` | `.\scripts\build-pdf.ps1 doc.tex slug -Verify` |
+| `scripts/build-pdf.sh doc.html slug --engine chromium` | `.\scripts\build-pdf.ps1 doc.html slug -Engine chromium` |
+| `scripts/fetch-vazirmatn.sh fonts` | `.\scripts\fetch-vazirmatn.ps1 fonts` |
+
+The `.py` helpers need no port — run them as `python scripts\check-fa.py …`.
+The `.ps1` scripts run on Windows PowerShell 5.1 *and* PowerShell 7.x, so
+the shell that ships with Windows is enough and `pwsh` is equally fine.
+They are Windows-only by design: under `pwsh` on Linux or macOS each one
+exits 2 and points at its `.sh` twin. If execution policy blocks them,
+start them with
+`powershell -ExecutionPolicy Bypass -File .\scripts\preflight.ps1` (or
+`pwsh -ExecutionPolicy Bypass -File …`) rather than relaxing the
+machine-wide policy.
+
+These traps are already handled inside the scripts, and any new `.ps1` code
+must handle them too. They are all about probing a native command for its
+exit code, which the scripts do constantly:
+
+- **5.1** turns each stderr line of a native command into an `ErrorRecord`
+  that honours `$ErrorActionPreference`. Under `Stop` the first line
+  throws — and headless Chromium, `latexmk -silent`, and a failing
+  `python -c "import …"` all write to stderr on ordinary paths. PowerShell
+  7.2 exempted redirected native stderr from `$ErrorActionPreference`, so
+  this one is 5.1-only; the twins still have to serve both.
+- **`$PSNativeCommandUseErrorActionPreference`** (7.3+) makes a non-zero
+  *exit code* raise `NativeCommandExitException`, which honours
+  `$ErrorActionPreference` too. It ships `$false`, so this is insurance
+  rather than a fix for a current default — but a profile or a CI runner
+  can set it, and `kpsewhich` exiting 1 means "package not installed", not
+  "abort the script".
+- **Command discovery.** `& 'pdfinfo'` runs full discovery and prefers an
+  alias, function, or cmdlet over the executable; those leave
+  `$LASTEXITCODE` stale, or unset in a fresh session, where StrictMode
+  then throws on the read. Worse, `Get-Command python` routinely returns
+  *several* matches on Windows — 3.13, 3.11, and the WindowsApps Store
+  stub are all on a typical `PATH` — so `$cmd.Source` is an array of paths
+  that nothing can execute. `Get-Tool` takes the first match, which is the
+  one PATH order would have selected anyway.
+- **A command that never launches.** If the executable cannot start,
+  nothing writes `$LASTEXITCODE`, so a stale or unset value reads as a
+  clean exit. That is how a probe like `python -c "import PIL"` can report
+  a missing module as installed. `Invoke-Tool` clears `$LASTEXITCODE`
+  before every call and reports 127 when it comes back unset.
+- **A GUI-subsystem executable is never waited for.** PowerShell blocks on
+  console applications only. `msedge.exe` and `chrome.exe` are GUI
+  binaries, so `& $browser --print-to-pdf …` returns the moment the
+  process starts: nothing is captured, nothing writes `$LASTEXITCODE`, and
+  the check for the finished PDF runs while the browser is still booting.
+  `Invoke-Tool` reads that as its "never launched" sentinel and reports
+  127 — which is why the HTML path failed on every Windows machine with
+  Edge until `Invoke-Browser` was split out. Only `Start-Process -Wait`
+  blocks on a GUI process, and it joins the arguments into one string, so
+  anything containing a space has to be quoted on the way in.
+
+All of these are neutralised in one place — the `Invoke-Tool` helper sets
+`$ErrorActionPreference = 'Continue'` and
+`$PSNativeCommandUseErrorActionPreference = $false` as function-scoped
+locals (they revert on return), and reads `$LASTEXITCODE` defensively.
+Route every native call through it, and always hand it the resolved path
+from `Get-Tool`, never a bare command name.
+
+Windows specifics worth knowing:
+
+- **Browser engine.** Edge is checked before Chrome — it ships with
+  Windows, so a browser fallback is almost always available. The headless
+  run gets its own `--user-data-dir`, because otherwise an already-open
+  Edge or Chrome window makes `--print-to-pdf` exit 0 without writing
+  anything.
+- **Poppler** (`pdfinfo`, `pdffonts`, `pdftoppm`, `pdfimages`) is not
+  present by default. Without it `-Verify` still checks that the PDF is
+  non-empty but cannot rasterise sample pages, and figure extraction is
+  unavailable. `winget install oschwartz10612.Poppler`.
+- **TeX.** MiKTeX (`winget install MiKTeX.MiKTeX`) can install `xepersian`
+  and `bidi` on demand; TeX Live for Windows works as well.
+- **`\IfFontExistsTF` lies on MiKTeX.** Asked about a face that is not
+  installed, MiKTeX does not answer "no" — it tries to *manufacture* a
+  METAFONT font for it. The name is truncated on the way
+  (`Couldn't open 'TeX Gyre Term.cfg'`), `makemf` fails, TeX carries on,
+  and the run dies much later in the driver with
+  `dvipdfmx:fatal: Invalid font: -1 (4)` and a truncated PDF. So a font
+  chain must test an **OS-native face first** — `Times New Roman`,
+  `Consolas` — and keep the TeX Gyre / Liberation / DejaVu names as the
+  tail that only Linux reaches, where fontconfig answers honestly.
+  `assets/rtl-document.tex` is ordered that way; preserve it.
+- **latexmk needs Perl, which MiKTeX does not ship.** `build-pdf` detects
+  this (latexmk dies without writing a `.log`) and falls back to calling
+  `xelatex` twice, so no action is required. Install Strawberry Perl only
+  if you want latexmk's bibliography reruns.
+- **MiKTeX's on-the-fly installer will stall an unattended build.** The
+  basic install carries only a small package set, and MiKTeX fetches the
+  rest during the first compile — `fancyvrb`, `bidi`, and the xepersian
+  dependencies among them. Out of the box it *asks first*, with a modal
+  dialog per package. A person clicks Install; an agent-driven build hangs
+  on a window it cannot see, with no error and no `.log`. Turn the prompt
+  off once, before the first build:
+
+  ```powershell
+  initexmf --set-config-value "[MPM]AutoInstall=1"
+  ```
+
+  `preflight` reports this setting whenever it detects MiKTeX, so check it
+  there rather than discovering it as a hung build. The first compile
+  afterwards is still slow — it is downloading packages — so give it time
+  before deciding it is stuck.
+- **Fonts.** There is no `fc-list`, so `preflight.ps1` reads the font
+  registry instead, and `fetch-vazirmatn.ps1` copies an installed
+  Vazirmatn from `C:\Windows\Fonts` or the per-user font directory before
+  it downloads anything.
+- **A variable font cannot be selected by family name.** Google Fonts
+  ships Vazirmatn as `Vazirmatn-VariableFont_wght.ttf`, and that is what
+  most Windows machines have installed. Asked for the *family*, XeTeX
+  hands the driver a named instance of it, which `xdvipdfmx` cannot
+  embed — `Invalid TTC index (not TTC font)`, then
+  `dvipdfmx:fatal: Invalid font: -1 (4)`, then no PDF. The identical file
+  loaded by **path** carries no instance index and embeds normally, so
+  `assets/rtl-document.tex` tries `fonts/Vazirmatn-Regular.ttf` before any
+  family name. Put the files there first (see below); `build-pdf` prints
+  that instruction when it recognises the driver error.
 
 ## Engine order
 

--- a/scripts/build-pdf.ps1
+++ b/scripts/build-pdf.ps1
@@ -1,0 +1,609 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Compile a Persian print document and copy the PDF to
+    $HOME\Documents\books. Windows counterpart of build-pdf.sh.
+
+.DESCRIPTION
+    Engine order for .tex: XeLaTeX (via latexmk when present). For .html:
+    a Chromium browser (Edge, then Chrome), then WeasyPrint. A *missing*
+    engine falls back; a *failing* engine does not - it reports the error
+    and stops, so a broken build is never quietly downgraded.
+
+    Only the destination path is written to stdout; every diagnostic goes
+    to stderr, so `$pdf = .\build-pdf.ps1 doc.tex slug` captures the path.
+
+.PARAMETER Path
+    The .tex or .html source to compile.
+
+.PARAMETER Slug
+    Filesystem-safe stem for the output PDF. Defaults to the source stem.
+
+.PARAMETER Verify
+    Report page count and embedded fonts, and rasterise sample pages to
+    PNG. Judge RTL from those images, never from pdftotext.
+
+.PARAMETER Engine
+    Force one engine: tex, chromium, or weasyprint.
+
+.EXAMPLE
+    .\build-pdf.ps1 doc.tex my-slug -Verify
+
+.EXAMPLE
+    .\build-pdf.ps1 doc.html my-slug -Engine chromium -Verify
+
+.NOTES
+    Runs on Windows PowerShell 5.1 and on PowerShell 7.x. Windows only:
+    under pwsh on Linux or macOS it stops and points at build-pdf.sh.
+
+    This file is deliberately pure ASCII: 5.1 decodes a BOM-less .ps1 with
+    the system ANSI code page, where a UTF-8 em dash turns into a curly
+    quote that terminates a string and breaks the parse. Keep it ASCII-only.
+
+    The Python helpers in this directory (check-fa.py, prepare-figures.py,
+    crop-source-figures.py, extract-pdf-pages.py) are cross-platform
+    already - run them with `python scripts\check-fa.py ...`.
+#>
+[CmdletBinding()]
+param(
+    # Not [Mandatory]: a mandatory parameter prompts before the platform
+    # guard below can run, so `pwsh ./build-pdf.ps1` on Linux would hang on
+    # a prompt instead of pointing at build-pdf.sh.
+    [Parameter(Position = 0)]
+    [string]$Path,
+
+    [Parameter(Position = 1)]
+    [string]$Slug,
+
+    [switch]$Verify,
+
+    [ValidateSet('tex', 'chromium', 'weasyprint')]
+    [string]$Engine
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+# Persian filenames and TeX log lines are UTF-8; do not let the console
+# code page mangle them.
+try { [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false) } catch { }
+
+function Write-Log {
+    param([string]$Message)
+    [Console]::Error.WriteLine("build-pdf: $Message")
+}
+
+function Test-Windows {
+    # 5.1 is Windows-only and has no $IsWindows; 7.x defines it on every
+    # platform. Test-Path keeps StrictMode from throwing on 5.1.
+    if (Test-Path 'variable:IsWindows') { return [bool]$IsWindows }
+    return $true
+}
+
+if (-not (Test-Windows)) {
+    Write-Log 'this script drives Windows tooling (registry fonts, Edge, MiKTeX).'
+    Write-Log 'On Linux or macOS run the POSIX twin instead:'
+    Write-Log '  scripts/build-pdf.sh <file.tex|file.html> <slug> --verify'
+    exit 2
+}
+
+if (-not $Path) {
+    Write-Log 'usage: build-pdf.ps1 <file.tex|file.html> [slug] [-Verify]'
+    Write-Log '                     [-Engine tex|chromium|weasyprint]'
+    exit 2
+}
+
+function Get-Tool {
+    # Resolve an executable on PATH; $null when absent. Filtering on
+    # Application keeps $LASTEXITCODE meaningful after the call.
+    #
+    # -First 1 is load-bearing: several pythons on PATH (3.13, 3.11, the
+    # WindowsApps stub) make Get-Command return an array, and $cmd.Source
+    # would then be an array of paths that the call operator cannot run.
+    # Get-Command yields them in PATH order, so the first is the one a bare
+    # name would have resolved to anyway.
+    param([string]$Name)
+    $cmd = Get-Command -Name $Name -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($cmd) { return $cmd.Source }
+    return $null
+}
+
+function Invoke-Tool {
+    # Run a *console* executable, capture merged stdout+stderr, return the
+    # exit code. A GUI-subsystem executable needs Invoke-Browser instead -
+    # see the note there.
+    #
+    # $Exe must be a resolved path from Get-Tool, never a bare name: the call
+    # operator runs full command discovery, which prefers an alias, function
+    # or cmdlet over the executable, and those leave $LASTEXITCODE stale.
+    #
+    # Both assignments below are function-scoped, so they shadow the caller's
+    # values and revert on return - no finally needed.
+    #
+    # 5.1: 2>&1 on a native command wraps each stderr line in an ErrorRecord
+    # and emits it through WriteError, which honours $ErrorActionPreference.
+    # Under 'Stop' the first stderr line throws - and headless Chromium,
+    # latexmk -silent, and a failing `python -c import` all write to stderr
+    # on paths this function must treat as ordinary results. (7.2+ exempted
+    # redirected native stderr from $ErrorActionPreference, so this trap is
+    # 5.1-only, but the twins have to serve both.)
+    #
+    # $PSNativeCommandUseErrorActionPreference (7.3+) makes a non-zero *exit
+    # code* raise NativeCommandExitException, which honours
+    # $ErrorActionPreference too. It ships $false, but a profile or a CI
+    # runner can set it, so opt out explicitly: this function reports exit
+    # codes on purpose - kpsewhich 1 means "package not installed", not
+    # "abort". On 5.1 the variable is simply unused.
+    param([string]$Exe, [string[]]$Arguments)
+    $ErrorActionPreference = 'Continue'
+    $PSNativeCommandUseErrorActionPreference = $false
+    # Clear the sentinel first. If the executable never launches, nothing
+    # updates $LASTEXITCODE, and a stale or unset value would read as a
+    # clean exit - turning a failed build into a reported success.
+    $global:LASTEXITCODE = $null
+    $out = $null
+    try { $out = & $Exe @Arguments 2>&1 }
+    catch { $out = $_.Exception.Message }
+    if ($null -eq $LASTEXITCODE) { $code = 127 } else { $code = $LASTEXITCODE }
+    return [pscustomobject]@{ ExitCode = $code; Output = $out }
+}
+
+function Invoke-Browser {
+    # Same contract as Invoke-Tool, but for a GUI-subsystem executable.
+    #
+    # PowerShell only waits for *console* applications. msedge.exe and
+    # chrome.exe are GUI binaries, so `& $browser --print-to-pdf ...`
+    # returns the instant the process is launched: nothing is captured,
+    # nothing writes $LASTEXITCODE, and the check for the finished PDF runs
+    # while the browser is still starting. Invoke-Tool reads that unset
+    # exit code as its "never launched" sentinel and reports 127, which is
+    # why the HTML path failed on every Windows machine that has Edge.
+    #
+    # Start-Process -Wait is the form that actually blocks on a GUI
+    # process. It hands the arguments over as one joined string instead of
+    # an argv array, so anything holding a space - every path under
+    # "Program Files", every slug with a space in it - has to be quoted
+    # here; the call operator did that itself.
+    param([string]$Exe, [string[]]$Arguments)
+    $stem = Join-Path ([IO.Path]::GetTempPath()) ('fa-run-' + [Guid]::NewGuid().ToString('N'))
+    $outFile = "$stem.out"
+    $errFile = "$stem.err"
+    $quoted = @($Arguments | ForEach-Object {
+        if ($_ -match '[\s"]') { '"' + ($_ -replace '"', '\"') + '"' } else { $_ }
+    })
+    try {
+        $p = Start-Process -FilePath $Exe -ArgumentList $quoted -Wait -PassThru `
+            -NoNewWindow -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+        $lines = @()
+        foreach ($f in @($outFile, $errFile)) {
+            if (Test-Path -LiteralPath $f) {
+                $lines += @(Get-Content -LiteralPath $f -ErrorAction SilentlyContinue)
+            }
+        }
+        return [pscustomobject]@{ ExitCode = $p.ExitCode; Output = $lines }
+    }
+    catch {
+        # Could not start at all: report it the way Invoke-Tool would.
+        return [pscustomobject]@{ ExitCode = 127; Output = @($_.Exception.Message) }
+    }
+    finally {
+        Remove-Item -LiteralPath $outFile, $errFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Write-ToolOutput {
+    param($Output)
+    if ($null -eq $Output) { return }
+    $Output | ForEach-Object { [Console]::Error.WriteLine($_) }
+}
+
+function Write-ToolFailure {
+    # A tool that fails silently still has to be reportable: without the
+    # exit code there is nothing to act on, and "build failed" alone is not
+    # a diagnosis.
+    param([string]$What, $Result)
+    Write-Log "$What failed with exit code $($Result.ExitCode)"
+    if ($null -eq $Result.Output -or @($Result.Output).Count -eq 0) {
+        Write-Log '  (the tool printed nothing on stdout or stderr)'
+    }
+    else {
+        Write-ToolOutput $Result.Output
+    }
+}
+
+function Test-XeLaTeX {
+    if (-not (Get-Tool 'xelatex')) { return $false }
+    # xepersian is the part that is usually missing on a bare TeX install.
+    $kpse = Get-Tool 'kpsewhich'
+    if ($kpse) {
+        # Exit code alone is not enough: MiKTeX's kpsewhich can exit 0 while
+        # printing nothing for a package the basic install does not carry.
+        # Require an actual path back.
+        $r = Invoke-Tool $kpse @('xepersian.sty')
+        if ($r.ExitCode -ne 0) { return $false }
+        $hit = $r.Output | Where-Object { "$_" -match 'xepersian\.sty' }
+        if (-not $hit) { return $false }
+    }
+    return $true
+}
+
+function Find-Chromium {
+    # Edge ships with Windows and is the same Chromium engine, so it is the
+    # first choice here; Chrome and a bare chromium build follow.
+    foreach ($name in 'msedge', 'chrome', 'chromium') {
+        $p = Get-Tool $name
+        if ($p) { return $p }
+    }
+    $roots = @(
+        $env:ProgramFiles,
+        ${env:ProgramFiles(x86)},
+        $env:LOCALAPPDATA
+    ) | Where-Object { $_ }
+    $relative = @(
+        'Microsoft\Edge\Application\msedge.exe',
+        'Google\Chrome\Application\chrome.exe',
+        'Chromium\Application\chrome.exe'
+    )
+    foreach ($rel in $relative) {
+        foreach ($root in $roots) {
+            $candidate = Join-Path $root $rel
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+        }
+    }
+    return $null
+}
+
+function Show-TexError {
+    param([string]$LogFile)
+    if (-not (Test-Path -LiteralPath $LogFile -PathType Leaf)) { return }
+    $errs = Get-Content -LiteralPath $LogFile -Encoding UTF8 |
+        Where-Object { $_ -like '!*' } |
+        Select-Object -First 20
+    if ($errs) {
+        Write-Log "--- first TeX errors in $LogFile ---"
+        $errs | ForEach-Object { [Console]::Error.WriteLine($_) }
+    }
+    else {
+        # A truncated log with no '!' line usually means the engine died
+        # mid-run rather than rejecting the document - say so instead of
+        # printing an empty section under a heading that promises errors.
+        Write-Log "no '!' error line in $LogFile; the engine stopped mid-run"
+    }
+    Write-Log '--- last 25 log lines ---'
+    Get-Content -LiteralPath $LogFile -Encoding UTF8 -Tail 25 |
+        ForEach-Object { [Console]::Error.WriteLine($_) }
+}
+
+function Show-DriverFailure {
+    # xdvipdfmx cannot embed a *named instance* of a variable font, and a
+    # named instance is exactly what XeTeX hands it for any family that is
+    # installed only as a variable face - Vazirmatn from Google Fonts among
+    # them. What it prints is "Invalid TTC index" and "Invalid font: -1 (4)",
+    # which says nothing about fonts to anyone who has not met it before.
+    # Translate it.
+    param($Output, [string]$SourceDir)
+    $hit = $Output | Where-Object {
+        "$_" -like '*Invalid TTC index*' -or "$_" -like '*Invalid font: -1*'
+    }
+    if (-not $hit) { return }
+    Write-Log 'that is a variable font: XeTeX selected a named instance of it and'
+    Write-Log '  the PDF driver cannot embed one. The same file loaded by path'
+    Write-Log '  works, so put the TTFs beside the document and rebuild:'
+    Write-Log "    scripts\fetch-vazirmatn.ps1 $(Join-Path $SourceDir 'fonts')"
+}
+
+# 0 = built, 1 = engine unavailable, 2 = engine present but failed.
+function Invoke-TexBuild {
+    param([string]$SourceName, [string]$Stem, [string]$Destination)
+    if (-not (Test-XeLaTeX)) { return 1 }
+    $pdf = "$Stem.pdf"
+    $log = "$Stem.log"
+    $xelatex = Get-Tool 'xelatex'
+    $latexmk = Get-Tool 'latexmk'
+    $useLatexmk = [bool]$latexmk
+    $r = $null
+
+    # Clear artefacts from a previous run first. Without this a stale .log
+    # makes "latexmk left no .log" read as "latexmk reached the compiler",
+    # so the fallback never fires and the old log gets reported as this
+    # build's error; a stale .pdf could likewise be shipped as a success.
+    Remove-Item -LiteralPath $log -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $pdf -Force -ErrorAction SilentlyContinue
+
+    if ($useLatexmk) {
+        Write-Log 'engine: latexmk -xelatex'
+        $r = Invoke-Tool $latexmk @(
+            '-xelatex', '-interaction=nonstopmode', '-halt-on-error',
+            '-silent', $SourceName)
+        if ($r.ExitCode -ne 0 -and -not (Test-Path -LiteralPath $log -PathType Leaf)) {
+            # No .log at all means the compiler was never reached - a
+            # latexmk problem (MiKTeX ships it as a Perl script, so a
+            # missing Perl kills it) rather than a broken document. Any
+            # real TeX error writes a .log first, so retrying here cannot
+            # hide one.
+            Write-Log 'latexmk wrote no .log, so it never reached the compiler:'
+            Write-ToolOutput $r.Output
+            Write-Log 'retrying with xelatex directly'
+            $useLatexmk = $false
+        }
+    }
+
+    if (-not $useLatexmk) {
+        Write-Log 'engine: xelatex (two passes)'
+        $r = Invoke-Tool $xelatex @(
+            '-interaction=nonstopmode', '-halt-on-error', $SourceName)
+        if ($r.ExitCode -eq 0) {
+            $r = Invoke-Tool $xelatex @(
+                '-interaction=nonstopmode', '-halt-on-error', $SourceName)
+        }
+    }
+
+    if ($r.ExitCode -ne 0) {
+        if (Test-Path -LiteralPath $log -PathType Leaf) {
+            Show-TexError $log
+        }
+        else {
+            # Never claim "the error is above" when nothing was printed.
+            Write-Log "no $log was written; the engine's own output follows"
+            Write-ToolOutput $r.Output
+        }
+        return 2
+    }
+    if (-not (Test-Path -LiteralPath $pdf -PathType Leaf)) {
+        Write-Log "expected PDF missing: $pdf"
+        return 2
+    }
+    # A zero exit code from xelatex only means TeX itself was happy. The
+    # PDF driver runs afterwards and reports its own failure in the log
+    # while xelatex still exits 0, so check for that before believing it.
+    if (Test-Path -LiteralPath $log -PathType Leaf) {
+        $driver = Get-Content -LiteralPath $log -Encoding UTF8 |
+            Where-Object { $_ -like '*driver return code*' }
+        if ($driver) {
+            Write-Log 'the PDF driver failed even though xelatex exited 0:'
+            $driver | ForEach-Object { [Console]::Error.WriteLine($_) }
+            Write-ToolOutput $r.Output
+            Show-DriverFailure $r.Output $srcDir
+            return 2
+        }
+    }
+    if (-not (Test-PdfStructure $pdf)) {
+        Write-Log "$pdf is truncated (no %%EOF); the driver did not finish"
+        Write-ToolOutput $r.Output
+        Show-DriverFailure $r.Output $srcDir
+        return 2
+    }
+    Copy-Item -LiteralPath $pdf -Destination $Destination -Force
+    return 0
+}
+
+function Test-PdfStructure {
+    # A PDF that exists is not a PDF that is complete. XeLaTeX can exit 0
+    # while the xdvipdfmx driver dies, leaving a truncated file with a valid
+    # header and no trailer - poppler then reports "Couldn't find trailer
+    # dictionary" and the page count is unknown.
+    param([string]$Pdf)
+    $item = Get-Item -LiteralPath $Pdf -ErrorAction SilentlyContinue
+    if (-not $item -or $item.Length -lt 100) { return $false }
+    # Read through the item's full path. The .NET file APIs resolve a
+    # relative path against [Environment]::CurrentDirectory, which
+    # Push-Location does not touch - and the TeX build calls this with a
+    # bare "<stem>.pdf" from inside the pushed source directory.
+    $bytes = [IO.File]::ReadAllBytes($item.FullName)
+    $head = [Text.Encoding]::ASCII.GetString($bytes, 0, [Math]::Min(8, $bytes.Length))
+    if ($head -notlike '%PDF-*') { return $false }
+    $tailLen = [Math]::Min(2048, $bytes.Length)
+    $tail = [Text.Encoding]::ASCII.GetString($bytes, $bytes.Length - $tailLen, $tailLen)
+    return $tail.Contains('%%EOF')
+}
+
+function ConvertTo-FileUri {
+    param([string]$LiteralPath)
+    return ([Uri](Resolve-Path -LiteralPath $LiteralPath).ProviderPath).AbsoluteUri
+}
+
+function Invoke-HtmlBuild {
+    param([string]$Html, [string]$Destination)
+
+    if ($Engine -ne 'weasyprint') {
+        $browser = Find-Chromium
+        if ($browser) {
+            Write-Log "engine: $([IO.Path]::GetFileName($browser)) --print-to-pdf"
+            # A dedicated profile directory keeps the headless run from
+            # attaching to an already-open Edge/Chrome window, which is the
+            # usual reason --print-to-pdf silently writes nothing on Windows.
+            $profileDir = Join-Path ([IO.Path]::GetTempPath()) ('fa-pdf-' + [Guid]::NewGuid().ToString('N'))
+            try {
+                # Without a virtual-time budget Chromium can print before the
+                # webfonts finish loading, which produces fallback boxes for
+                # Persian. --disable-gpu paints raster images as black
+                # rectangles; do not pass it.
+                $r = Invoke-Browser $browser @(
+                    '--headless=new',
+                    '--no-pdf-header-footer',
+                    '--virtual-time-budget=10000',
+                    '--run-all-compositor-stages-before-draw',
+                    "--user-data-dir=$profileDir",
+                    "--print-to-pdf=$Destination",
+                    (ConvertTo-FileUri $Html)
+                )
+            }
+            finally {
+                Remove-Item -LiteralPath $profileDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+            if ($r.ExitCode -ne 0) {
+                Write-ToolFailure "$([IO.Path]::GetFileName($browser)) --print-to-pdf" $r
+                Write-Log "  source: $Html"
+                Write-Log "  target: $Destination"
+                return 2
+            }
+            # Headless Chromium can exit 0 without writing the file.
+            if (-not (Test-Path -LiteralPath $Destination -PathType Leaf)) {
+                Write-Log "the browser exited 0 but wrote no PDF: $Destination"
+                Write-ToolOutput $r.Output
+                return 2
+            }
+            if (-not (Test-PdfStructure $Destination)) {
+                Write-Log "the browser wrote a truncated PDF: $Destination"
+                Write-ToolOutput $r.Output
+                return 2
+            }
+            return 0
+        }
+    }
+
+    $weasyprint = Get-Tool 'weasyprint'
+    if ($weasyprint) {
+        Write-Log 'engine: weasyprint (keeps its bidi warnings; read them)'
+        $r = Invoke-Tool $weasyprint @($Html, $Destination)
+        if ($r.ExitCode -ne 0) {
+            Write-ToolFailure 'weasyprint' $r
+            return 2
+        }
+        return 0
+    }
+
+    $python = Get-Tool 'python'
+    if (-not $python) { $python = Get-Tool 'python3' }
+    if ($python) {
+        $probe = Invoke-Tool $python @('-c', 'import weasyprint')
+        if ($probe.ExitCode -eq 0) {
+            Write-Log 'engine: weasyprint (python module)'
+            $code = 'from weasyprint import HTML; import sys; HTML(sys.argv[1]).write_pdf(sys.argv[2])'
+            $r = Invoke-Tool $python @('-c', $code, $Html, $Destination)
+            if ($r.ExitCode -ne 0) {
+                Write-ToolOutput $r.Output
+                return 2
+            }
+            return 0
+        }
+    }
+
+    Write-Log 'no HTML engine: install Edge/Chrome, or WeasyPrint in a venv'
+    Write-Log '  (py -m venv .venv; .venv\Scripts\pip install weasyprint)'
+    return 1
+}
+
+function Test-OutputPdf {
+    param([string]$Pdf, [string]$WorkDir, [string]$Stem)
+    if (-not (Test-PdfStructure $Pdf)) {
+        Write-Log "VERIFY FAIL: $Pdf is empty or truncated (no %%EOF trailer)"
+        return $false
+    }
+    $pages = $null
+    $pdfinfo = Get-Tool 'pdfinfo'
+    if ($pdfinfo) {
+        $r = Invoke-Tool $pdfinfo @($Pdf)
+        $line = $r.Output | Where-Object { $_ -match '^Pages:\s+(\d+)' } | Select-Object -First 1
+        if ($line -and "$line" -match '^Pages:\s+(\d+)') { $pages = [int]$Matches[1] }
+        if ($pages) { Write-Log "pages: $pages" } else { Write-Log 'pages: unknown' }
+    }
+    $pdffonts = Get-Tool 'pdffonts'
+    if ($pdffonts) {
+        Write-Log 'embedded fonts:'
+        $r = Invoke-Tool $pdffonts @($Pdf)
+        $r.Output | Select-Object -First 8 | ForEach-Object { [Console]::Error.WriteLine($_) }
+        $embedded = $r.Output | Select-Object -Skip 2 | Where-Object { "$_" -match '\byes\b' }
+        if (-not $embedded) {
+            Write-Log 'VERIFY WARN: no embedded font; Persian may render as boxes'
+        }
+    }
+    $pdftoppm = Get-Tool 'pdftoppm'
+    if ($pdftoppm) {
+        $prefix = Join-Path $WorkDir "verify-$Stem"
+        Invoke-Tool $pdftoppm @('-png', '-r', '110', '-f', '1', '-l', '1', $Pdf, "$prefix-first") | Out-Null
+        if ($pages -and $pages -gt 1) {
+            Invoke-Tool $pdftoppm @('-png', '-r', '110', '-f', "$pages", '-l', "$pages", $Pdf, "$prefix-last") | Out-Null
+        }
+        Write-Log "rasterised samples: $prefix-*.png -- look at them, do not"
+        Write-Log '  judge RTL from pdftotext'
+    }
+    else {
+        Write-Log 'pdftoppm missing: install poppler to rasterise sample pages'
+        Write-Log '  (winget install oschwartz10612.Poppler, or scoop install poppler)'
+    }
+    return $true
+}
+
+# --- main -------------------------------------------------------------
+
+if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    Write-Log "not a file: $Path"
+    exit 1
+}
+
+$srcItem = Get-Item -LiteralPath $Path
+$srcDir = $srcItem.DirectoryName
+$srcName = $srcItem.Name
+$srcStem = [IO.Path]::GetFileNameWithoutExtension($srcName)
+$ext = $srcItem.Extension.TrimStart('.').ToLowerInvariant()
+if (-not $Slug) { $Slug = $srcStem }
+
+$destDir = Join-Path $HOME 'Documents\books'
+$dest = Join-Path $destDir "$Slug.pdf"
+New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+
+$rc = 1
+Push-Location -LiteralPath $srcDir
+try {
+    switch ($ext) {
+        'tex' {
+            if ($Engine -eq 'chromium' -or $Engine -eq 'weasyprint') {
+                $html = "$srcStem.html"
+                if (-not (Test-Path -LiteralPath $html -PathType Leaf)) {
+                    Write-Log "no $html next to the .tex"
+                    exit 1
+                }
+                $rc = Invoke-HtmlBuild $html $dest
+            }
+            else {
+                $rc = Invoke-TexBuild $srcName $srcStem $dest
+                if ($rc -eq 2) {
+                    Write-Log 'XeLaTeX is installed but the build failed.'
+                    Write-Log 'Fix the problem reported above. Not falling back to HTML - a'
+                    Write-Log '  fallback here would hide a real error in the .tex.'
+                    exit 1
+                }
+                if ($rc -eq 1) {
+                    Write-Log 'xelatex or xepersian not available (see scripts\preflight.ps1)'
+                    $html = "$srcStem.html"
+                    if (Test-Path -LiteralPath $html -PathType Leaf) {
+                        Write-Log "falling back to $html"
+                        $rc = Invoke-HtmlBuild $html $dest
+                    }
+                    else {
+                        Write-Log 'write the HTML from assets\rtl-document.html and retry:'
+                        Write-Log "  build-pdf.ps1 $(Join-Path $srcDir $html) $Slug"
+                        exit 1
+                    }
+                }
+            }
+        }
+        { $_ -in 'html', 'htm' } {
+            $rc = Invoke-HtmlBuild $srcName $dest
+        }
+        default {
+            Write-Log "expected .tex or .html, got: $srcName"
+            exit 2
+        }
+    }
+
+    if ($rc -ne 0) {
+        Write-Log 'build failed'
+        exit 1
+    }
+
+    # Verification that cannot fail the build is decoration. If -Verify was
+    # asked for and it fails, do not print the destination path as though
+    # the document were usable.
+    if ($Verify -and -not (Test-OutputPdf $dest $srcDir $Slug)) {
+        Write-Log 'verification failed; this PDF is not usable'
+        exit 1
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Output $dest
+exit 0

--- a/scripts/build-pdf.sh
+++ b/scripts/build-pdf.sh
@@ -77,23 +77,70 @@ show_tex_error() {
   tail -25 "$logfile" >&2
 }
 
+# xdvipdfmx cannot embed a *named instance* of a variable font, and a named
+# instance is exactly what XeTeX hands it for any family that is installed
+# only as a variable face. What it prints is "Invalid TTC index" and
+# "Invalid font: -1 (4)", which says nothing about fonts to anyone who has
+# not met it before. Translate it.
+explain_driver_failure() {
+  case $1 in
+    *'Invalid TTC index'*|*'Invalid font: -1'*) ;;
+    *) return 0 ;;
+  esac
+  log 'that is a variable font: XeTeX selected a named instance of it and'
+  log '  the PDF driver cannot embed one. The same file loaded by path'
+  log '  works, so put the TTFs beside the document and rebuild:'
+  log "    scripts/fetch-vazirmatn.sh ${src_dir}/fonts"
+}
+
+# A PDF that exists is not a PDF that is complete. XeLaTeX exits 0 while the
+# xdvipdfmx driver dies, leaving a header with no trailer; poppler then
+# reports "Couldn't find trailer dictionary" and the page count is unknown.
+pdf_is_complete() {
+  local f=$1
+  [[ -s $f ]] || return 1
+  head -c 8 "$f" | grep -q '%PDF-' || return 1
+  tail -c 2048 "$f" | grep -q '%%EOF' || return 1
+  return 0
+}
+
 # 0 = built, 1 = engine unavailable, 2 = engine present but failed.
 compile_tex() {
   have_xelatex || return 1
-  local pdf="${stem_src}.pdf"
+  local pdf="${stem_src}.pdf" logfile="${stem_src}.log"
+  local out
+  # Keep the engine output instead of discarding it. The PDF driver reports
+  # its own failure on stderr rather than in the .log, so throwing it away
+  # leaves nothing to diagnose.
   if command -v latexmk >/dev/null 2>&1; then
     log "engine: latexmk -xelatex"
-    latexmk -xelatex -interaction=nonstopmode -halt-on-error \
-            -silent "$src_base" >/dev/null 2>&1 || {
-      show_tex_error "${stem_src}.log"; return 2; }
+    out=$(latexmk -xelatex -interaction=nonstopmode -halt-on-error \
+            -silent "$src_base" 2>&1) || {
+      printf '%s\n' "$out" >&2; show_tex_error "$logfile"; return 2; }
   else
     log "engine: xelatex (two passes)"
-    xelatex -interaction=nonstopmode -halt-on-error "$src_base" \
-      >/dev/null 2>&1 || { show_tex_error "${stem_src}.log"; return 2; }
-    xelatex -interaction=nonstopmode -halt-on-error "$src_base" \
-      >/dev/null 2>&1 || { show_tex_error "${stem_src}.log"; return 2; }
+    out=$(xelatex -interaction=nonstopmode -halt-on-error "$src_base" 2>&1) || {
+      printf '%s\n' "$out" >&2; show_tex_error "$logfile"; return 2; }
+    out=$(xelatex -interaction=nonstopmode -halt-on-error "$src_base" 2>&1) || {
+      printf '%s\n' "$out" >&2; show_tex_error "$logfile"; return 2; }
   fi
   [[ -f $pdf ]] || { log "expected PDF missing: ${src_dir}/${pdf}"; return 2; }
+  # A zero exit code from xelatex only means TeX itself was happy. The PDF
+  # driver runs afterwards and reports its own failure in the log while
+  # xelatex still exits 0, so check for that before believing it.
+  if [[ -f $logfile ]] && grep -q 'driver return code' "$logfile"; then
+    log "the PDF driver failed even though xelatex exited 0:"
+    grep -n 'driver return code' "$logfile" >&2
+    printf '%s\n' "$out" >&2
+    explain_driver_failure "$out"
+    return 2
+  fi
+  if ! pdf_is_complete "$pdf"; then
+    log "${pdf} is truncated (no %%EOF); the driver did not finish"
+    printf '%s\n' "$out" >&2
+    explain_driver_failure "$out"
+    return 2
+  fi
   cp -f "$pdf" "$dest" || return 2
   return 0
 }

--- a/scripts/check-fa.py
+++ b/scripts/check-fa.py
@@ -32,6 +32,18 @@ import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 
+# Every finding this tool prints quotes Persian, and on Windows an
+# unredirected stdout defaults to the console ANSI code page (cp1252), which
+# cannot encode a single Persian letter. The first finding then dies with
+# UnicodeEncodeError and every check after it goes unreported - a lint that
+# exits non-zero for the wrong reason and hides the rest of its own output.
+# Force UTF-8 rather than depending on the locale.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):  # not a TextIOWrapper (test capture)
+        pass
+
 ZWNJ = "\u200c"
 FA_RANGE = "\u0600-\u06ff\ufb50-\ufdff\ufe70-\ufeff"
 FA_CHAR = re.compile(f"[{FA_RANGE}]")

--- a/scripts/fetch-vazirmatn.ps1
+++ b/scripts/fetch-vazirmatn.ps1
@@ -1,0 +1,213 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Put Vazirmatn Regular + Bold (Western digits) into a fonts directory
+    for @font-face embedding. Windows counterpart of fetch-vazirmatn.sh.
+
+.DESCRIPTION
+    Never the UI-FD / Farsi-digits cut, which draws Eastern Arabic digits.
+    Reuses an installed system face or a previous download before hitting
+    the network, so an offline machine with the font already present still
+    works. Vazirmatn is SIL Open Font License 1.1; keep the licence file
+    beside the TTFs when you ship the HTML.
+
+    Only the resulting font paths go to stdout; progress goes to stderr.
+
+.PARAMETER Destination
+    Directory to place the TTFs in. Defaults to .\fonts.
+
+.PARAMETER Version
+    Vazirmatn release to download when no local copy is found.
+
+.EXAMPLE
+    .\fetch-vazirmatn.ps1 fonts
+
+.NOTES
+    Runs on Windows PowerShell 5.1 and on PowerShell 7.x. Windows only:
+    under pwsh on Linux or macOS it stops and points at fetch-vazirmatn.sh.
+
+    Keep this file pure ASCII: 5.1 decodes a BOM-less .ps1 with the system
+    ANSI code page, where a UTF-8 em dash becomes a curly quote that
+    terminates a string and breaks the parse.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Destination = 'fonts',
+
+    [string]$Version = $(if ($env:VAZIRMATN_VERSION) { $env:VAZIRMATN_VERSION } else { '33.003' })
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+try { [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false) } catch { }
+
+# PowerShell 5.1 still negotiates TLS 1.0 by default; GitHub refuses it.
+try {
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.SecurityProtocolType]::Tls12 -bor [Net.ServicePointManager]::SecurityProtocol
+}
+catch { }
+
+$Want = @('Vazirmatn-Regular.ttf', 'Vazirmatn-Bold.ttf')
+$Cache = Join-Path $env:LOCALAPPDATA 'fa-fonts'
+$Url = "https://github.com/rastikerdar/vazirmatn/releases/download/v$Version/vazirmatn-v$Version.zip"
+
+# Registry font names are space-separated ("Vazirmatn UI FD Bold
+# (TrueType)"), so match FD as a whole token rather than as "UI-FD".
+$FdPattern = '(?i)(^|[\s_-])(UI[\s_-]?)?FD([\s_-]|$|\s*\()|Farsi.*Digit'
+# Vazirmatn ships SemiBold, ExtraBold and Black; none of them is Bold.
+$BoldPattern = '(?i)(^|[\s_-])bold([\s_-]|$|\s*\()'
+$OtherWeights = '(?i)semi|extra|ultra|demi|thin|light|medium|black|italic'
+
+function Write-Log {
+    param([string]$Message)
+    [Console]::Error.WriteLine("fetch-vazirmatn: $Message")
+}
+
+function Test-Windows {
+    # 5.1 is Windows-only and has no $IsWindows; 7.x defines it everywhere.
+    if (Test-Path 'variable:IsWindows') { return [bool]$IsWindows }
+    return $true
+}
+
+if (-not (Test-Windows)) {
+    Write-Log 'this script reads the Windows font registry.'
+    Write-Log 'On Linux or macOS run the POSIX twin instead:'
+    Write-Log '  scripts/fetch-vazirmatn.sh [dest-dir]'
+    exit 2
+}
+
+function Test-HaveAll {
+    param([string]$Directory)
+    if (-not (Test-Path -LiteralPath $Directory -PathType Container)) { return $false }
+    foreach ($f in $Want) {
+        $p = Join-Path $Directory $f
+        $item = Get-Item -LiteralPath $p -ErrorAction SilentlyContinue
+        if (-not $item -or $item.Length -eq 0) { return $false }
+    }
+    return $true
+}
+
+function Write-Report {
+    foreach ($f in $Want) { Write-Output (Join-Path $Destination $f) }
+}
+
+function Find-InstalledVazirmatn {
+    # Windows keeps installed faces in the font registry; the value is a
+    # bare filename for machine fonts and a full path for per-user ones.
+    $sources = @(
+        @{ Key = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts'
+           Dir = (Join-Path $env:WINDIR 'Fonts') },
+        @{ Key = 'HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts'
+           Dir = (Join-Path $env:LOCALAPPDATA 'Microsoft\Windows\Fonts') }
+    )
+    $found = @{}
+    foreach ($s in $sources) {
+        if (-not (Test-Path -LiteralPath $s.Key)) { continue }
+        $props = Get-ItemProperty -LiteralPath $s.Key
+        foreach ($p in $props.PSObject.Properties) {
+            if ($p.Name -like 'PS*') { continue }
+            if ($p.Name -notmatch '(?i)vazirmatn') { continue }
+            # Reject the Farsi-digit cut outright.
+            if ($p.Name -match $FdPattern) { continue }
+            $value = [string]$p.Value
+            if ([IO.Path]::IsPathRooted($value)) { $path = $value }
+            else { $path = Join-Path $s.Dir $value }
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { continue }
+            if ($p.Name -match $BoldPattern -and $p.Name -notmatch $OtherWeights) {
+                if (-not $found.ContainsKey('Bold')) { $found['Bold'] = $path }
+            }
+            elseif ($p.Name -notmatch $BoldPattern -and $p.Name -notmatch $OtherWeights) {
+                if (-not $found.ContainsKey('Regular')) { $found['Regular'] = $path }
+            }
+        }
+    }
+    return $found
+}
+
+# --- main -------------------------------------------------------------
+
+New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+New-Item -ItemType Directory -Path $Cache -Force | Out-Null
+
+# 0. Already in place.
+if (Test-HaveAll $Destination) {
+    Write-Log "already present in $Destination"
+    Write-Report
+    exit 0
+}
+
+# 1. A previous download.
+if (Test-HaveAll $Cache) {
+    Write-Log "using cache $Cache"
+    foreach ($f in $Want) {
+        Copy-Item -LiteralPath (Join-Path $Cache $f) -Destination (Join-Path $Destination $f) -Force
+    }
+    Write-Report
+    exit 0
+}
+
+# 2. An installed system copy - no network needed.
+$installed = Find-InstalledVazirmatn
+if ($installed.ContainsKey('Regular')) {
+    Write-Log 'copying the installed face'
+    Copy-Item -LiteralPath $installed['Regular'] `
+        -Destination (Join-Path $Destination 'Vazirmatn-Regular.ttf') -Force
+    if ($installed.ContainsKey('Bold')) {
+        Copy-Item -LiteralPath $installed['Bold'] `
+            -Destination (Join-Path $Destination 'Vazirmatn-Bold.ttf') -Force
+    }
+    else {
+        Copy-Item -LiteralPath $installed['Regular'] `
+            -Destination (Join-Path $Destination 'Vazirmatn-Bold.ttf') -Force
+    }
+    foreach ($f in $Want) {
+        Copy-Item -LiteralPath (Join-Path $Destination $f) `
+            -Destination (Join-Path $Cache $f) -Force -ErrorAction SilentlyContinue
+    }
+    Write-Report
+    exit 0
+}
+
+# 3. Download.
+$tmp = Join-Path ([IO.Path]::GetTempPath()) ('fa-font-' + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+    Write-Log "downloading v$Version"
+    $zip = Join-Path $tmp 'v.zip'
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $zip -UseBasicParsing -TimeoutSec 60
+    }
+    catch {
+        Write-Log "download failed: $Url"
+        Write-Log "  $($_.Exception.Message)"
+        Write-Log 'fall back to any installed fa face, or install Vazirmatn'
+        Write-Log '  from https://github.com/rastikerdar/vazirmatn/releases'
+        exit 1
+    }
+
+    Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force
+    foreach ($f in $Want) {
+        $src = Get-ChildItem -LiteralPath $tmp -Recurse -Filter $f -File -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if (-not $src) {
+            Write-Log "missing $f in archive; the release layout may have changed"
+            exit 1
+        }
+        Copy-Item -LiteralPath $src.FullName -Destination (Join-Path $Destination $f) -Force
+        Copy-Item -LiteralPath $src.FullName -Destination (Join-Path $Cache $f) -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Log 'sha256'
+    foreach ($f in $Want) {
+        $h = Get-FileHash -LiteralPath (Join-Path $Destination $f) -Algorithm SHA256
+        [Console]::Error.WriteLine("$($h.Hash.ToLowerInvariant())  $f")
+    }
+}
+finally {
+    Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Report
+exit 0

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -1,0 +1,326 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Report which PDF engines, fonts, and extraction tools exist on this
+    machine and what to install for the missing ones. Windows counterpart
+    of preflight.sh. Run before planning a build.
+
+.DESCRIPTION
+    The report goes to stdout, like preflight.sh, so it can be captured or
+    piped.
+
+.PARAMETER RequireTex
+    Exit 1 when XeLaTeX + xepersian is not usable, so a caller can gate on
+    the preferred engine.
+
+.EXAMPLE
+    .\preflight.ps1
+
+.EXAMPLE
+    .\preflight.ps1 -RequireTex
+
+.NOTES
+    Runs on Windows PowerShell 5.1 and on PowerShell 7.x. Windows only:
+    under pwsh on Linux or macOS it stops and points at preflight.sh.
+
+    Keep this file pure ASCII: 5.1 decodes a BOM-less .ps1 with the system
+    ANSI code page, where a UTF-8 em dash becomes a curly quote that
+    terminates a string and breaks the parse.
+#>
+[CmdletBinding()]
+param(
+    [switch]$RequireTex
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+try { [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false) } catch { }
+
+function Write-Ok {
+    param([string]$Name, [string]$Note = '')
+    Write-Output ('  yes   {0,-22} {1}' -f $Name, $Note)
+}
+
+function Write-No {
+    param([string]$Name, [string]$Note = '')
+    Write-Output ('  NO    {0,-22} {1}' -f $Name, $Note)
+}
+
+function Get-Tool {
+    # -First 1 is load-bearing: several pythons on PATH (3.13, 3.11, the
+    # WindowsApps stub) make Get-Command return an array, and $cmd.Source
+    # would then be an array of paths that the call operator cannot run.
+    # Get-Command yields them in PATH order, so the first is the one a bare
+    # name would have resolved to anyway.
+    param([string]$Name)
+    $cmd = Get-Command -Name $Name -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($cmd) { return $cmd.Source }
+    return $null
+}
+
+function Invoke-Tool {
+    # See the long note in build-pdf.ps1. Both assignments are
+    # function-scoped and revert on return.
+    #
+    # 5.1: 2>&1 routes native stderr through WriteError, which under
+    # $ErrorActionPreference='Stop' throws on the first line. A missing
+    # Python module prints a traceback on stderr, so probing without this
+    # would abort the whole report on a perfectly ordinary machine.
+    #
+    # $PSNativeCommandUseErrorActionPreference (7.3+) makes a non-zero exit
+    # code throw as well. It ships $false, but a profile or CI runner can
+    # set it, and this whole script is built on probing exit codes - so opt
+    # out explicitly. On 5.1 the variable is simply unused.
+    #
+    # $Exe must be a resolved path from Get-Tool, never a bare name: the
+    # call operator prefers an alias, function or cmdlet over the
+    # executable, and those leave $LASTEXITCODE stale.
+    param([string]$Exe, [string[]]$Arguments)
+    $ErrorActionPreference = 'Continue'
+    $PSNativeCommandUseErrorActionPreference = $false
+    # Clear the sentinel first. If the executable never launches, nothing
+    # updates $LASTEXITCODE and a stale or unset value would read as a clean
+    # exit - which would report a missing Python module as installed.
+    $global:LASTEXITCODE = $null
+    $out = $null
+    try { $out = & $Exe @Arguments 2>&1 }
+    catch { $out = $_.Exception.Message }
+    if ($null -eq $LASTEXITCODE) { $code = 127 } else { $code = $LASTEXITCODE }
+    return [pscustomobject]@{ ExitCode = $code; Output = $out }
+}
+
+function Test-Windows {
+    # 5.1 is Windows-only and has no $IsWindows; 7.x defines it everywhere.
+    if (Test-Path 'variable:IsWindows') { return [bool]$IsWindows }
+    return $true
+}
+
+if (-not (Test-Windows)) {
+    [Console]::Error.WriteLine('preflight: this script reads Windows registry fonts and Program Files.')
+    [Console]::Error.WriteLine('preflight: On Linux or macOS run the POSIX twin instead:')
+    [Console]::Error.WriteLine('preflight:   scripts/preflight.sh')
+    exit 2
+}
+
+function Get-Python {
+    foreach ($n in 'python', 'python3', 'py') {
+        $p = Get-Tool $n
+        if ($p) { return $p }
+    }
+    return $null
+}
+
+function Test-PyModule {
+    param([string]$Python, [string]$Module)
+    if (-not $Python) { return $false }
+    $r = Invoke-Tool $Python @('-c', "import $Module")
+    return ($r.ExitCode -eq 0)
+}
+
+function Find-Browser {
+    foreach ($name in 'msedge', 'chrome', 'chromium') {
+        $p = Get-Tool $name
+        if ($p) { return $p }
+    }
+    $roots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALAPPDATA) |
+        Where-Object { $_ }
+    $relative = @(
+        'Microsoft\Edge\Application\msedge.exe',
+        'Google\Chrome\Application\chrome.exe',
+        'Chromium\Application\chrome.exe'
+    )
+    foreach ($rel in $relative) {
+        foreach ($root in $roots) {
+            $candidate = Join-Path $root $rel
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+        }
+    }
+    return $null
+}
+
+function Get-InstalledFontFamily {
+    # Windows has no fc-list. Read the font registry, which covers both
+    # machine-wide (C:\Windows\Fonts) and per-user installs.
+    $keys = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts',
+        'HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts'
+    )
+    $names = New-Object System.Collections.Generic.List[string]
+    foreach ($key in $keys) {
+        if (-not (Test-Path -LiteralPath $key)) { continue }
+        $props = Get-ItemProperty -LiteralPath $key
+        foreach ($p in $props.PSObject.Properties) {
+            if ($p.Name -like 'PS*') { continue }
+            $names.Add($p.Name)
+        }
+    }
+    return $names
+}
+
+$tex = $false
+$browser = $false
+$weasy = $false
+$faFont = $false
+
+$python = Get-Python
+
+Write-Output 'PDF engines'
+$xelatex = Get-Tool 'xelatex'
+if ($xelatex) {
+    $xepersianMissing = $false
+    $kpse = Get-Tool 'kpsewhich'
+    if ($kpse) {
+        # Exit code alone is not enough: MiKTeX's kpsewhich can exit 0 while
+        # printing nothing for a package the basic install does not carry.
+        # Require an actual path back.
+        $r = Invoke-Tool $kpse @('xepersian.sty')
+        $hit = $r.Output | Where-Object { "$_" -match 'xepersian\.sty' }
+        if ($r.ExitCode -ne 0 -or -not $hit) { $xepersianMissing = $true }
+    }
+    if ($xepersianMissing) {
+        Write-No 'xepersian.sty' 'xelatex is present but the Persian package is not'
+    }
+    else {
+        $v = Invoke-Tool $xelatex @('--version')
+        $ver = "$($v.Output | Select-Object -First 1)"
+        Write-Ok 'xelatex + xepersian' $ver
+        $tex = $true
+
+        # MiKTeX installs missing packages on the fly and, by default, asks
+        # first with a modal dialog. That is fine for a human at a keyboard
+        # and fatal for an unattended or agent-driven build, which simply
+        # hangs on an invisible window. AutoInstall: 1 = yes, 0 = no,
+        # anything else (2) = ask.
+        if ($ver -match '(?i)miktex') {
+            $initexmf = Get-Tool 'initexmf'
+            if ($initexmf) {
+                $a = Invoke-Tool $initexmf @('--show-config-value=[MPM]AutoInstall')
+                $auto = "$($a.Output | Select-Object -First 1)".Trim()
+                if ($auto -eq '1') {
+                    Write-Ok 'MiKTeX auto-install' 'missing packages install without prompting'
+                }
+                else {
+                    Write-No 'MiKTeX auto-install' "set to '$auto'; a build will stop on a dialog"
+                    Write-Output '        fix: initexmf --set-config-value "[MPM]AutoInstall=1"'
+                }
+            }
+        }
+    }
+}
+else {
+    Write-No 'xelatex' 'preferred engine unavailable'
+}
+if (Get-Tool 'latexmk') { Write-Ok 'latexmk' 'used for reruns and bibliography' }
+
+$browserPath = Find-Browser
+if ($browserPath) {
+    Write-Ok ([IO.Path]::GetFileName($browserPath)) 'HTML print fallback'
+    $browser = $true
+}
+else {
+    Write-No 'edge/chrome' 'no browser print fallback'
+}
+
+if ((Get-Tool 'weasyprint') -or (Test-PyModule $python 'weasyprint')) {
+    Write-Ok 'weasyprint' 'HTML print fallback'
+    $weasy = $true
+    Write-Output '        note: ignores unicode-bidi: isolate - rely on dir="ltr"'
+    Write-Output '        attributes and keep every cluster in one isolate'
+}
+else {
+    Write-No 'weasyprint' 'py -m venv .venv; .venv\Scripts\pip install weasyprint'
+}
+
+Write-Output ''
+Write-Output 'Fonts'
+# The Farsi-digit cut must never be selected: it draws Eastern Arabic
+# digits. Registry names are space-separated ("Vazirmatn UI FD Bold
+# (TrueType)"), so match FD as a whole token, not as "UI-FD".
+$fdPattern = '(?i)(^|[\s_-])(UI[\s_-]?)?FD([\s_-]|$|\s*\()|Farsi.*Digit'
+$families = Get-InstalledFontFamily
+$faCandidates = $families | Where-Object {
+    $_ -match '(?i)vazir|iran|nazli|behdad|shabnam|sahel|samim|estedad|noto\s*(naskh|kufi)|arabic|tahoma|segoe\s*ui'
+}
+if ($faCandidates) {
+    $shown = ($faCandidates | Sort-Object -Unique | Select-Object -First 8) -join ', '
+    Write-Ok 'fa-capable faces' $shown
+    $faFont = $true
+    $vazir = $faCandidates | Where-Object { $_ -match '(?i)vazirmatn' -and $_ -notmatch $fdPattern }
+    if ($vazir) {
+        Write-Ok 'Vazirmatn' 'preferred text face'
+    }
+    else {
+        Write-No 'Vazirmatn' 'run scripts\fetch-vazirmatn.ps1 fonts'
+    }
+    if ($faCandidates | Where-Object { $_ -match $fdPattern }) {
+        Write-Output '        warn: a Farsi-digit cut is installed; never select it'
+    }
+}
+else {
+    Write-No 'fa-capable face' 'run scripts\fetch-vazirmatn.ps1 fonts'
+}
+
+Write-Output ''
+Write-Output 'Source extraction and verification'
+foreach ($t in 'pdftotext', 'pdfimages', 'pdftoppm', 'pdfinfo', 'pdffonts') {
+    if (Get-Tool $t) { Write-Ok $t } else { Write-No $t 'part of poppler' }
+}
+foreach ($t in 'curl', 'tar', 'git') {
+    if (Get-Tool $t) { Write-Ok $t } else { Write-No $t }
+}
+if ($python) {
+    Write-Ok 'python' "required by scripts\check-fa.py ($python)"
+}
+else {
+    Write-No 'python' 'check-fa.py will not run'
+}
+if (Test-PyModule $python 'PIL.Image') {
+    Write-Ok 'Pillow' 'scripts\prepare-figures.py'
+}
+elseif ((Get-Tool 'magick') -or (Get-Tool 'convert')) {
+    Write-Ok 'ImageMagick' 'scripts\prepare-figures.py fallback'
+}
+else {
+    Write-No 'Pillow/ImageMagick' 'figures cannot be flattened; pip install pillow'
+}
+if (Test-PyModule $python 'pymupdf') {
+    Write-Ok 'PyMuPDF' 'scripts\crop-source-figures.py'
+}
+else {
+    Write-No 'PyMuPDF' 'cannot crop PDF artwork; pip install pymupdf'
+}
+
+Write-Output ''
+Write-Output 'Verdict'
+if ($tex) {
+    Write-Output '  build .tex with XeLaTeX - best print RTL'
+}
+elseif ($browser) {
+    Write-Output '  no TeX: build .html with Edge/Chrome (full CSS bidi support)'
+}
+elseif ($weasy) {
+    Write-Output '  no TeX and no browser: build .html with WeasyPrint, and keep'
+    Write-Output '  every English cluster in a single dir="ltr" isolate'
+}
+else {
+    Write-Output '  no engine can produce a PDF - stop and tell the user'
+}
+if (-not $faFont) { Write-Output '  fetch a Persian font before building' }
+
+if (-not $tex) {
+    Write-Output ''
+    Write-Output 'Install the preferred engine (Windows):'
+    Write-Output '  winget install MiKTeX.MiKTeX'
+    Write-Output '  then let MiKTeX install xepersian on first use, or:'
+    Write-Output '  mpm --install=xepersian --install=bidi'
+}
+if (-not (Get-Tool 'pdftoppm')) {
+    Write-Output ''
+    Write-Output 'Install poppler for extraction and -Verify rasterisation:'
+    Write-Output '  winget install oschwartz10612.Poppler'
+    Write-Output '  (or: scoop install poppler)'
+}
+
+if ($RequireTex -and -not $tex) { exit 1 }
+exit 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -220,6 +220,88 @@ else
   fail=1
 fi
 
+# build-pdf.sh must not hand back a PDF the driver never finished. xelatex
+# exits 0 while xdvipdfmx dies, so a truncated file with a %PDF header and
+# no trailer used to be copied to the destination as a success. Stubs stand
+# in for the toolchain so this runs anywhere.
+stub=$(mktemp -d)
+work=$(mktemp -d)
+trap 'rm -rf "$stub" "$work"' EXIT
+
+cat >"$stub/kpsewhich" <<'STUB'
+#!/bin/sh
+echo "/usr/share/texmf/tex/xelatex/xepersian/xepersian.sty"
+STUB
+cat >"$stub/xelatex" <<'STUB'
+#!/bin/sh
+for a; do case "$a" in *.tex) s=$(basename "$a" .tex);; esac; done
+case "$XELATEX_MODE" in
+  ok)       echo "log line" > "$s.log"
+            printf '%%PDF-1.7\n1 0 obj\n<<>>\nendobj\ntrailer\n%%%%EOF\n' > "$s.pdf"
+            exit 0 ;;
+  # Exit 0, but the driver died: the log says so and the PDF is truncated.
+  driver)   printf 'Error 1 (driver return code) generating output;\n' > "$s.log"
+            printf '%%PDF-1.7\n1 0 obj\n<</Filter/FlateD' > "$s.pdf"
+            exit 0 ;;
+  # The same, with the message a variable font actually produces.
+  varfont)  printf 'Error 1 (driver return code) generating output;\n' > "$s.log"
+            echo "xdvipdfmx:warning: Invalid TTC index (not TTC font): Vazirmatn-VariableFont_wght.ttf"
+            echo "xdvipdfmx:fatal: Invalid font: -1 (4)"
+            printf '%%PDF-1.7\n1 0 obj\n<</Filter/FlateD' > "$s.pdf"
+            exit 0 ;;
+  *)        echo "xelatex: cannot execute" >&2; exit 127 ;;
+esac
+STUB
+chmod +x "$stub"/*
+
+expect_build() {
+  local label=$1 mode=$2 want_rc=$3
+  shift 3
+  local out rc
+  rm -f "$work"/*.log "$work"/*.pdf
+  cp "$here/../assets/rtl-document.tex" "$work/probe.tex"
+  out=$(PATH="$stub:$PATH" XELATEX_MODE="$mode" \
+        bash "$here/../scripts/build-pdf.sh" "$work/probe.tex" "fa-selftest" 2>&1)
+  rc=$?
+  local missing=() phrase
+  for phrase in "$@"; do
+    grep -qF -- "$phrase" <<<"$out" || missing+=("$phrase")
+  done
+  if [[ $rc -ne $want_rc ]]; then
+    echo "FAIL build-pdf $label: exit $rc, wanted $want_rc"
+    echo "$out" | sed 's/^/    /'
+    fail=1
+  elif [[ ${#missing[@]} -gt 0 ]]; then
+    echo "FAIL build-pdf $label: missing from output: ${missing[*]}"
+    echo "$out" | sed 's/^/    /'
+    fail=1
+  else
+    echo "ok   build-pdf $label"
+  fi
+}
+
+expect_build "succeeds on a complete PDF" ok 0 "engine: xelatex"
+expect_build "fails when the PDF driver dies behind a zero exit code" driver 1 \
+  "the PDF driver failed even though xelatex exited 0" "driver return code"
+# "Invalid font: -1 (4)" is unactionable on its own. The driver is refusing a
+# named instance of a variable font, and the fix is to load the file by path
+# instead - say that, and name the command that puts it there.
+expect_build "explains a variable-font driver failure" varfont 1 \
+  "that is a variable font" "fetch-vazirmatn.sh"
+
+# The .tex template must try the local fonts/ directory before any family
+# name: a variable font picked by name cannot be embedded at all.
+tex_code=$(grep -v '^[[:space:]]*%' "$here/../assets/rtl-document.tex")
+file_at=$(grep -nF -- 'fonts/Vazirmatn-Regular.ttf' <<<"$tex_code" | head -1 | cut -d: -f1)
+name_at=$(grep -nF -- '{Vazirmatn}' <<<"$tex_code" | head -1 | cut -d: -f1)
+if [[ -n $file_at && -n $name_at && $file_at -lt $name_at ]]; then
+  echo "ok   font chain persian tries fonts/ before the family name"
+else
+  echo "FAIL font chain persian must test fonts/Vazirmatn-Regular.ttf before"
+  echo "     {Vazirmatn}; a variable font picked by name cannot be embedded"
+  fail=1
+fi
+
 if [[ $fail -eq 0 ]]; then
   echo "all tests passed"
 else

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -204,6 +204,22 @@ else
   fail=1
 fi
 
+# check-fa.py prints Persian, so it must not depend on the console encoding.
+# On Windows an unredirected stdout is cp1252 and the first finding dies with
+# UnicodeEncodeError, taking every later check down with it.
+cp1252_out=$(PYTHONIOENCODING=cp1252 python3 "$lint" "$fixtures/bad.tex"              --domains all 2>&1) || true
+if grep -q UnicodeEncodeError <<<"$cp1252_out"; then
+  echo "FAIL check-fa.py dies on a non-UTF-8 stdout (Windows console)"
+  echo "$cp1252_out" | sed 's/^/    /' | tail -5
+  fail=1
+elif grep -q full-page-figure <<<"$cp1252_out"; then
+  echo "ok   check-fa.py forces UTF-8 output"
+else
+  echo "FAIL check-fa.py under cp1252 did not report the last check"
+  echo "$cp1252_out" | sed 's/^/    /' | tail -5
+  fail=1
+fi
+
 if [[ $fail -eq 0 ]]; then
   echo "all tests passed"
 else

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -302,6 +302,76 @@ else
   fail=1
 fi
 
+# The .tex template resolves fonts with \IfFontExistsTF chains whose last
+# entry is unguarded: if that face is missing too, fontspec aborts the
+# build. A chain made only of Linux faces therefore cannot compile on
+# Windows, which is exactly how "DejaVu Serif" broke a MiKTeX build. Each
+# chain must name at least one face that ships with Windows.
+#
+# Strip comment lines: a face named only in the prose above a chain does not
+# make the chain compile, and matching it would make this test toothless.
+tex_prose=$(grep -v '^[[:space:]]*%' "$here/../assets/rtl-document.tex")
+check_font_chain() {
+  local label=$1 setter=$2
+  shift 2
+  local found=0 face
+  # -F: the setter names start with a backslash, which grep would otherwise
+  # read as a regex escape ('\s' matches whitespace, not a literal "\s").
+  if ! grep -qF -- "$setter" <<<"$tex_prose"; then
+    echo "FAIL font chain $label: no $setter in the template"
+    fail=1
+    return
+  fi
+  for face in "$@"; do
+    grep -qF -- "$face" <<<"$tex_prose" && found=1
+  done
+  if [[ $found -eq 1 ]]; then
+    echo "ok   font chain $label reaches a Windows face"
+  else
+    echo "FAIL font chain $label is Linux-only; it cannot compile on Windows"
+    echo "     add one of: $*"
+    fail=1
+  fi
+}
+check_font_chain "persian"   '\settextfont'      'Tahoma' 'Segoe UI' 'Arial'
+check_font_chain "latin"     '\setlatintextfont' 'Times New Roman' 'Cambria' 'Arial'
+check_font_chain "monospace" '\setmonofont'      'Consolas' 'Courier New'
+
+# MiKTeX answers \IfFontExistsTF "yes" for faces it does not have and then
+# dies in the driver, so the OS-native face must be tested FIRST, not last.
+check_font_order() {
+  local label=$1 native=$2 trap_face=$3
+  local native_at trap_at
+  native_at=$(grep -nF -- "$native" <<<"$tex_prose" | head -1 | cut -d: -f1)
+  trap_at=$(grep -nF -- "$trap_face" <<<"$tex_prose" | head -1 | cut -d: -f1)
+  if [[ -z $native_at || -z $trap_at ]]; then
+    echo "FAIL font order $label: expected both '$native' and '$trap_face'"
+    fail=1
+  elif [[ $native_at -lt $trap_at ]]; then
+    echo "ok   font order $label tests the OS face before $trap_face"
+  else
+    echo "FAIL font order $label: '$trap_face' is tested before '$native';"
+    echo "     on MiKTeX that reaches makemf and kills the PDF driver"
+    fail=1
+  fi
+}
+check_font_order "latin"     'Times New Roman' 'TeX Gyre Termes'
+check_font_order "monospace" 'Consolas'        'TeX Gyre Cursor'
+
+# build-pdf.ps1: the browser must not go through Invoke-Tool. Chromium is a
+# GUI-subsystem binary, and PowerShell does not wait for those - `& msedge`
+# returns before the PDF exists and never sets $LASTEXITCODE, which
+# Invoke-Tool reports as exit 127. Only Start-Process -Wait blocks.
+ps1="$here/../scripts/build-pdf.ps1"
+if grep -q 'Invoke-Browser \$browser' "$ps1" &&
+   grep -q 'Start-Process' "$ps1" && grep -q -- '-Wait' "$ps1"; then
+  echo "ok   build-pdf.ps1 waits for the browser"
+else
+  echo "FAIL build-pdf.ps1 must launch the browser with Start-Process -Wait;"
+  echo "     & msedge.exe returns before the PDF is written"
+  fail=1
+fi
+
 if [[ $fail -eq 0 ]]; then
   echo "all tests passed"
 else


### PR DESCRIPTION
Stacked on #9 and #10 — this branch contains their commits, and the diff
here collapses to the nine files below once they land.

Windows has no `bash`, no `fc-list`, and no `/home/$USER`, so today the
whole toolchain around the skill is Linux/macOS only. This adds a
same-named `.ps1` twin for each of the three shell scripts, with the same
behaviour and the same output contract (path on stdout, diagnostics on
stderr):

| POSIX | Windows |
| --- | --- |
| `scripts/preflight.sh` | `.\scripts\preflight.ps1` |
| `scripts/build-pdf.sh doc.tex slug --verify` | `.\scripts\build-pdf.ps1 doc.tex slug -Verify` |
| `scripts/fetch-vazirmatn.sh fonts` | `.\scripts\fetch-vazirmatn.ps1 fonts` |

The `.py` helpers already run everywhere and are not duplicated. Each `.ps1`
refuses to run under `pwsh` on Linux/macOS and points at its `.sh` twin, so
there is one obvious right script per platform.

## The template could not compile on Windows either

Worth calling out separately, because it is a bug in the current `.tex`
rather than a gap in tooling. Every `\IfFontExistsTF` chain ends in an
**unguarded** face, and all three tails were Linux-only, so on Windows
fontspec aborts before the first page:

```
! Package fontspec Error:
l.52 ...DejaVu Serif}\setdigitfont{DejaVu Serif}}}
```

Each chain now reaches a face that ships with Windows, and the OS-native
face is tested **first**. That ordering is load-bearing: on MiKTeX
`\IfFontExistsTF` does not answer "no" for a missing face — it tries to
manufacture a METAFONT font, truncates the name (`Couldn't open 'TeX Gyre
Term.cfg'`), `makemf` fails, and the run dies much later in the driver.
On Linux fontconfig answers honestly, so the TeX Gyre / DejaVu tail still
wins there and nothing changes.

## What is Windows-specific and worth reviewing

`references/pdf-output.md` gains a Windows section documenting these; the
`.ps1` sources carry the same notes at the call sites.

- **PowerShell does not wait for GUI-subsystem executables.**
  `msedge.exe`/`chrome.exe` are GUI binaries, so `& $browser --print-to-pdf`
  returns before the PDF is written and never sets `$LASTEXITCODE`. Only
  `Start-Process -Wait` blocks, and it joins arguments into one string, so
  paths with spaces have to be quoted going in.
- **Windows PowerShell 5.1** turns each stderr line of a native command
  into an `ErrorRecord` honouring `$ErrorActionPreference`; under `Stop`
  the first line throws, and headless Chromium and `latexmk -silent` both
  write to stderr on ordinary paths.
- **`$PSNativeCommandUseErrorActionPreference`** (7.3+) makes a non-zero
  exit code throw. `kpsewhich` exiting 1 means "not installed", not "abort".
- **Command discovery.** `& 'pdfinfo'` prefers an alias/function/cmdlet over
  the executable and leaves `$LASTEXITCODE` stale, and `Get-Command python`
  routinely returns several matches on Windows.
- **latexmk needs Perl, which MiKTeX does not ship.** Detected (latexmk dies
  without writing a `.log`) and handled by calling `xelatex` twice.
- **MiKTeX's on-the-fly installer** asks with a modal dialog by default,
  which hangs an unattended build on a window it cannot see. `preflight.ps1`
  reports the setting and prints the one-line fix.
- No `fc-list`, so `preflight.ps1` reads the font registry instead.

## Tests

CI gains a step asserting every `.sh` has a same-named `.ps1`, that each
`.ps1` is pure ASCII (5.1 decodes a BOM-less script with the ANSI code page,
where a UTF-8 em dash becomes a quote and breaks the parse), that it carries
`#Requires -Version 5.1`, that no PowerShell-7-only syntax appears, and that
anything reading `$LASTEXITCODE` opts out of the 7.4+ throw. Verified it
catches a planted em dash, a planted `??`, a removed `#Requires`, and a
deleted twin.

`tests/run.sh` gains checks that every font chain reaches a Windows face,
that the OS face is tested before the MiKTeX trap face, and that the browser
is launched through `Start-Process -Wait` rather than the console-command
helper. All fail when the corresponding fix is reverted.

Ran for real on Windows 11 with PowerShell 5.1 **and** 7.6, MiKTeX 25.12 +
xepersian 26.01, Edge 141:

- `preflight.ps1` — correct report of engines, registry fonts, and the
  MiKTeX auto-install setting
- `build-pdf.ps1 assets\rtl-document.tex … -Verify` — 2 pages,
  `Vazirmatn-Regular` + `TimesNewRomanPSMT` + `Consolas` embedded
- `build-pdf.ps1 assets\rtl-document.html … -Verify` — 2 pages, Vazirmatn
  embedded, including with a slug containing a space
- `fetch-vazirmatn.ps1` — reuses the installed face offline
- all three parse cleanly under 5.1 and 7.x

`bash tests/run.sh`, `shellcheck -S warning`, and `python3 -m py_compile`
pass on this branch.

`.gitignore` also learns the files this toolchain writes beside the
template (`*.aux`, `*.log`, `assets/*.pdf`, `verify-*.png`, `fonts/`) — the
Vazirmatn TTFs in particular are OFL 1.1 and should stay untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)